### PR TITLE
Enhance Post Creation API: Category, Tag Handling, and Default Fallbacks; Add Get Tags Endpoint

### DIFF
--- a/docs/create-post.md
+++ b/docs/create-post.md
@@ -28,6 +28,8 @@ To create a new post, make a `POST` request with the required parameters include
 | status            | string | The status of the post (e.g., `publish`).    |
 | author            | int    | The ID of the author of the post.            |
 | featured_image    | string | URL of the new featured image for the post.  |
+| category          | string | Comma-separated list of category IDs.        |
+| tag               | string | Comma-separated list of tags.                |
 
 ### Example 
 
@@ -43,7 +45,9 @@ $http({
         title: 'Sample Title',
         content: 'Sample content',
         status: 'publish',
-        author: 1
+        author: 1,
+        category: '2,5', 
+        tag: 'WordPress,API' 
     }
 }).then(function successCallback(response) {
     console.log('Post created:', response.data.data);

--- a/docs/get-tags.md
+++ b/docs/get-tags.md
@@ -1,9 +1,9 @@
-# `/categories` 
-The `/categories` endpoint retrieves a list of category IDs.
+# `/tags` 
+The `/tags` endpoint retrieves a list of tags
 
 ## Endpoint
 
-- **URL**: `/wp-json/sm-connect/v1/categories`
+- **URL**: `/wp-json/sm-connect/v1/tags`
 - **Method**: `GET`
 - **Authentication**: Bearer Token
 
@@ -19,7 +19,7 @@ To access this endpoint, make a `GET` request and include an `Authorization` hea
 
 ## Response
 
-The response will provide details about the categories.
+The response will provide details about the tags.
 
 ### Success Response
 
@@ -29,7 +29,7 @@ When the request is successful, the response will be:
     "status": 200,
     "message": "Operation successful",
     "data": {
-        "categories": {
+        "tags": {
             "1": {
                 "name": "Test Category",
                 "id": 2,
@@ -50,12 +50,12 @@ When the request is successful, the response will be:
 ```javascript
 $http({
     method: 'GET',
-    url: 'SITE_URL/wp-json/sm-connect/v1/categories',
+    url: 'SITE_URL/wp-json/sm-connect/v1/tags',
     headers: {
         'Authorization': 'Bearer <your_access_token>'
     }
 }).then(function successCallback(response) {
-    console.log('Categories:', response.data.data.categories);
+    console.log('tags:', response.data.data.tags);
 }, function errorCallback(response) {
     console.error('Error:', response.data.message);
 });

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,6 +14,7 @@ Welcome to the documentation for the **SM Post Connector** plugin. This plugin i
 	- [Delete Post](delete-post.md)
 	- [Get Authors](get-authors.md)
 	- [Get Categories](get-categories.md)
+	- [Get Tags](get-tags.md)
 - [FAQ](faq.md)
 - [Support](#support)
 

--- a/docs/update-post.md
+++ b/docs/update-post.md
@@ -30,6 +30,8 @@ To update a post, make a `POST` request with the required parameters included in
 | status           | string | The new status of the post (e.g., `publish`). | 
 | author           | int    | The ID of the author of the post.             | 
 | featured_image   | string | URL of the new featured image for the post.   | 
+| category         | string | Comma-separated list of category IDs.         |
+| tag              | string | Comma-separated list of tags.                 |
 
 ### Example 
 
@@ -48,6 +50,8 @@ $http({
         status: 'publish',
         author: 1,
         featured_image: 'https://cdn.pixabay.com/photo/2018/07/10/21/53/tournament-3529744_1280.jpg'
+        category: '2,5', 
+        tag: 'WordPress,API' 
     }
 }).then(function successCallback(response) {
     console.log('Post updated:', response.data.data);

--- a/includes/Endpoints/GetTags.php
+++ b/includes/Endpoints/GetTags.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace VPlugins\SMPostConnector\Endpoints;
+
+use WP_REST_Request;
+use VPlugins\SMPostConnector\Middleware\AuthMiddleware;
+use VPlugins\SMPostConnector\Helper\Globals;
+use VPlugins\SMPostConnector\Helper\Response;
+
+/**
+ * Class GetTags
+ *
+ * Registers a REST API endpoint for retrieving tags.
+ *
+ * @package VPlugins\SMPostConnector\Endpoints
+ */
+class GetTags {
+    /**
+     * @var AuthMiddleware
+     */
+    protected $auth_middleware;
+
+    /**
+     * GetTags constructor.
+     *
+     * Initializes the AuthMiddleware instance and registers the REST API routes.
+     */
+    public function __construct() {
+        $this->auth_middleware = new AuthMiddleware();
+        add_action('rest_api_init', [$this, 'register_routes']);
+    }
+
+    /**
+     * Registers the REST API route for retrieving tags.
+     *
+     * Adds a route for retrieving tags using a GET request.
+     * The route is registered under the namespace 'sm-connect/v1' and the endpoint '/tags'.
+     */
+    public function register_routes() {
+        register_rest_route('sm-connect/v1', '/tags', [
+            'methods' => 'GET',
+            'callback' => [$this, 'get_tags'],
+            'permission_callback' => [$this->auth_middleware, 'permissions_check']
+        ]);
+    }
+
+    /**
+     * Handles the request to retrieve tags.
+     *
+     * Retrieves a list of tags, including their name, ID, and number of posts.
+     *
+     * @param WP_REST_Request $request The request object for retrieving tags.
+     * 
+     * @return \WP_REST_Response The response object containing the list of tags.
+     */
+    public function get_tags(WP_REST_Request $request) {
+        $tags = Globals::get_tags();
+        $formattedTags = [];
+        $tagCount = 1;
+
+        foreach ($tags as $tag) {
+            $formattedTags[$tagCount] = [
+                'name' => $tag->name,
+                'id' => $tag->term_id,
+                'num_posts' => $tag->count
+            ];
+            $tagCount++;
+        }
+
+        return Response::success(
+            Globals::get_success_message('tags_retrieved'),
+            [
+                'tags' => $formattedTags
+            ]
+        );
+    }
+}

--- a/includes/Endpoints/Status.php
+++ b/includes/Endpoints/Status.php
@@ -88,7 +88,7 @@ class Status {
             ],
         ];
     
-        $success_message = 'Status retrieved successfully.'; // Custom message
+        $success_message = 'status_retrieved';
     
         // Use the Response helper for a standard format
         return Response::success($success_message, $data);

--- a/includes/Helper/Globals.php
+++ b/includes/Helper/Globals.php
@@ -118,6 +118,7 @@ class Globals {
             'post_deleted' => __('Post deleted successfully', 'sm-post-connector'),
             'categories_retrieved' => __('Categories retrieved successfully', 'sm-post-connector'),
             'authors_retrieved' => __('Authors retrieved successfully', 'sm-post-connector'),
+            'invalid_author_id' => __('Invalid author ID', 'sm-post-connector'),
             'post_id_required' => __('Post ID is required', 'sm-post-connector'),
             'post_not_found' => __('Post not found', 'sm-post-connector'),
             'post_moved_to_trash' => __('Post moved to trash successfully', 'sm-post-connector'),

--- a/includes/Helper/Globals.php
+++ b/includes/Helper/Globals.php
@@ -80,6 +80,17 @@ class Globals {
     }
 
     /**
+     * Retrieves a list of all tags.
+     *
+     * @return array An array of tag objects.
+     */
+    public static function get_tags() {
+        return get_tags([
+            'hide_empty' => false
+        ]);
+    }
+
+    /**
      * Retrieves a list of users with specific roles.
      *
      * @return array An array of user objects.

--- a/includes/Helper/Globals.php
+++ b/includes/Helper/Globals.php
@@ -117,6 +117,7 @@ class Globals {
             'post_updated' => __('Post updated successfully', 'sm-post-connector'),
             'post_deleted' => __('Post deleted successfully', 'sm-post-connector'),
             'categories_retrieved' => __('Categories retrieved successfully', 'sm-post-connector'),
+            'tags_retrieved' => __('Tags retrieved successfully', 'sm-post-connector'),
             'authors_retrieved' => __('Authors retrieved successfully', 'sm-post-connector'),
             'invalid_author_id' => __('Invalid author ID', 'sm-post-connector'),
             'post_id_required' => __('Post ID is required', 'sm-post-connector'),

--- a/includes/Helper/Globals.php
+++ b/includes/Helper/Globals.php
@@ -112,7 +112,7 @@ class Globals {
      */
     public static function get_success_message($key) {
         $messages = [
-            'status_retrieved' => __('Version information retrieved successfully', 'sm-post-connector'),
+            'status_retrieved' => __('Status information retrieved successfully', 'sm-post-connector'),
             'post_created' => __('Post created successfully', 'sm-post-connector'),
             'post_updated' => __('Post updated successfully', 'sm-post-connector'),
             'post_deleted' => __('Post deleted successfully', 'sm-post-connector'),

--- a/includes/Helper/Globals.php
+++ b/includes/Helper/Globals.php
@@ -135,6 +135,6 @@ class Globals {
             'error' => __('An error occurred', 'sm-post-connector')
         ];
 
-        return $messages[$key] ?? __('Operation successful', 'sm-post-connector');
+        return $messages[$key] ?? __( $key , 'sm-post-connector');
     }
 }

--- a/includes/Helper/Response.php
+++ b/includes/Helper/Response.php
@@ -160,6 +160,6 @@ class Response {
      */
     public static function error($key = '') {
         $message = Globals::get_success_message($key);
-        return self::create_response(500, $message);
+        return self::create_response(400, $message);
     }
 }

--- a/sm-post-connector.php
+++ b/sm-post-connector.php
@@ -22,6 +22,7 @@ use VPlugins\SMPostConnector\Endpoints\{
     UpdatePost,
     GetAuthors,
     GetCategories,
+    GetTags,
     Status
 };
 
@@ -45,6 +46,7 @@ class EndpointRegistry {
         GetCategories::class,
         Status::class,
         Token::class,
+        GetTags::class
     ];
 
     /**


### PR DESCRIPTION
## Description

- Modified the /create-post endpoint to handle categories and tags as comma-separated strings.
- Added logic to convert these strings into arrays and validate their values accordingly.
- Implemented a fallback mechanism to set a default category if no categories are provided in the request.
- Added a similar fallback for the author ID, allowing the system to use a default author if none is provided.
- Enhanced the post creation logic to validate the provided post status, ensuring that ‘future’ posts require a date, and ‘publish’ posts cannot have a future date.
- Added validation to check for duplicate post titles when creating a new post.
- Updated the logic for setting default category and author. These defaults will only be applied when creating a new post ($is_update is false) and the respective fields are empty or not set.
- Added the /get_tags API endpoint to retrieve a list of tags with their respective names, IDs, and post associations.
- Ensured consistency in API responses for both categories and tags endpoints, maintaining a standardized format for returning data.
- Addressed minor bugs related to the post creation logic and ensured better handling of edge cases (e.g., missing parameters).
- Optimized category and tag string processing to avoid unnecessary transformations.

## Related Jira Issue

- Jira Ticket: [Jira Ticket Number](https://vendasta.jira.com/browse/WSP-1751)

## Screenshots (if applicable)
(No screenshots are required for this PR)

@vplugins/vplugin @vplugins/websitepro 