### PR TITLE
Wsp 1806 change plugin name

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,7 +40,7 @@ jobs:
 
     - name: Zip the plugin
       run: |
-        zip -r sm-post-connector-package.zip . -x "*.git*" -x "*.github*" -x "*.yml" -x "phpunit.xml" -x "tests/**" -x "docs/**"
+        zip -r blog-post-connector-package.zip . -x "*.git*" -x "*.github*" -x "*.yml" -x "phpunit.xml" -x "tests/**" -x "docs/**"
 
     - name: Create Release
       id: create_release
@@ -60,6 +60,6 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./sm-post-connector-package.zip
-        asset_name: sm-post-connector-package.zip
+        asset_path: ./blog-post-connector-package.zip
+        asset_name: blog-post-connector-package.zip
         asset_content_type: application/zip

--- a/blog-post-connector.php
+++ b/blog-post-connector.php
@@ -1,10 +1,10 @@
 <?php
 /**
- * Plugin Name: SM Post Connector
+ * Plugin Name: Blog Post Connector
  * Description: A plugin to connect WordPress with the Social Marketing tool.
  * Version: 0.0.3
  * Author: Website Pro WordPress Team
- * Text Domain: sm-post-connector
+ * Text Domain: blog-post-connector
  */
 
 if (!defined('ABSPATH')) {
@@ -14,10 +14,10 @@ if (!defined('ABSPATH')) {
 // Autoload the classes using Composer
 require_once __DIR__ . '/vendor/autoload.php';
 
-use VPlugins\SMPostConnector\Auth\Token;
-use VPlugins\SMPostConnector\Updater\Update;
-use VPlugins\SMPostConnector\Webhook\Webhook;
-use VPlugins\SMPostConnector\Endpoints\{
+use VPlugins\BlogPostConnector\Auth\Token;
+use VPlugins\BlogPostConnector\Updater\Update;
+use VPlugins\BlogPostConnector\Webhook\Webhook;
+use VPlugins\BlogPostConnector\Endpoints\{
     CreatePost,
     DeletePost,
     UpdatePost,

--- a/blog-post-connector.php
+++ b/blog-post-connector.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Blog Post Connector
  * Description: A plugin to publish blogs to your WordPress website.
- * Version: 0.0.3
+ * Version: 1.0.0Beta
  * Author: Website Pro, a WordPress hosting platform.
  * Text Domain: blog-post-connector
  */

--- a/blog-post-connector.php
+++ b/blog-post-connector.php
@@ -1,9 +1,9 @@
 <?php
 /**
  * Plugin Name: Blog Post Connector
- * Description: A plugin to connect WordPress with the Social Marketing tool.
+ * Description: A plugin to publish blogs to your WordPress website.
  * Version: 0.0.3
- * Author: Website Pro WordPress Team
+ * Author: Website Pro, a WordPress hosting platform.
  * Text Domain: blog-post-connector
  */
 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "vplugins/blog-post-connector",
-    "description": "A plugin to connect WordPress with the Social Marketing tool.",
+    "description": "A plugin to publish blogs to your WordPress website.",
     "type": "wordpress-plugin",
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -1,10 +1,10 @@
 {
-    "name": "vplugins/sm-post-connector",
+    "name": "vplugins/blog-post-connector",
     "description": "A plugin to connect WordPress with the Social Marketing tool.",
     "type": "wordpress-plugin",
     "autoload": {
         "psr-4": {
-            "VPlugins\\SMPostConnector\\": "includes/"
+            "VPlugins\\BlogPostConnector\\": "includes/"
         }
     },
     "require": {

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,4 +1,4 @@
-title: SM Post Connector
+title: Blog Post Connector
 description: A plugin to connect WordPress with the Social Marketing tool.
 show_downloads: true
 google_analytics:

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,5 +1,5 @@
 title: Blog Post Connector
-description: A plugin to connect WordPress with the Social Marketing tool.
+description: A plugin to publish blogs to your WordPress website.
 show_downloads: true
 google_analytics:
 theme: jekyll-theme-minimal

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,14 +1,14 @@
-# FAQ - SM Post Connector Plugin
+# FAQ - Blog Post Connector Plugin
 
 ## General Questions
 
-### What is the SM Post Connector Plugin?
+### What is the Blog Post Connector Plugin?
 
-The SM Post Connector Plugin is a WordPress plugin that provides REST API endpoints for managing posts, authors, categories, and more. It allows you to interact with WordPress data programmatically, enabling CRUD (Create, Read, Update, Delete) operations via HTTP requests.
+The Blog Post Connector Plugin is a WordPress plugin that provides REST API endpoints for managing posts, authors, categories, and more. It allows you to interact with WordPress data programmatically, enabling CRUD (Create, Read, Update, Delete) operations via HTTP requests.
 
 ### How do I authenticate requests?
 
-Requests to the SM Post Connector API endpoints require authentication via a Bearer token. Ensure you include the `Authorization` header with a valid token in your requests.
+Requests to the Blog Post Connector API endpoints require authentication via a Bearer token. Ensure you include the `Authorization` header with a valid token in your requests.
 
 ## Endpoints FAQ
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
-# SM Post Connector
+# Blog Post Connector
 
-Welcome to the documentation for the **SM Post Connector** plugin. This plugin is designed to help you easily manage and integrate Social Media Post Connector within your WordPress site.
+Welcome to the documentation for the **Blog Post Connector** plugin. This plugin is designed to help you easily manage and integrate Social Media Post Connector within your WordPress site.
 
 ## Table of Contents
 
@@ -20,14 +20,14 @@ Welcome to the documentation for the **SM Post Connector** plugin. This plugin i
 
 ## Introduction
 
-The SM Post Connector plugin allows WordPress site administrators to seamlessly manage social media posts. With the help of various API endpoints, you can create, update, and delete posts, as well as fetch authors and categories information.
+The Blog Post Connector plugin allows WordPress site administrators to seamlessly manage social media posts. With the help of various API endpoints, you can create, update, and delete posts, as well as fetch authors and categories information.
 
 ## Installation
 
-To install the SM Post Connector plugin, follow these steps:
+To install the Blog Post Connector plugin, follow these steps:
 
-1. Download the plugin from the [GitHub repository](https://github.com/vplugins/sm-post-connector).
-2. Upload the plugin files to the `/wp-content/plugins/sm-post-connector` directory.
+1. Download the plugin from the [GitHub repository](https://github.com/vplugins/blog-post-connector).
+2. Upload the plugin files to the `/wp-content/plugins/blog-post-connector` directory.
 3. Activate the plugin through the 'Plugins' menu in WordPress.
 
 ## Configuration
@@ -39,7 +39,7 @@ After installation, configure the plugin settings:
 
 ## API Endpoints
 
-The SM Post Connector plugin provides the following API endpoints:
+The Blog Post Connector plugin provides the following API endpoints:
 
 -  **Create Post**: Allows you to create a new post. [View Details](create-post.md)
 -  **Update Post**: Allows you to update an existing post. [View Details](update-post.md)
@@ -57,6 +57,6 @@ For frequently asked questions, please refer to the [FAQ section](faq.md).
 
 If you encounter any issues or need further assistance, please reach out to our support team:
 
--  **GitHub Issues**: [Report an Issue](https://github.com/vplugins/sm-post-connector/issues)
+-  **GitHub Issues**: [Report an Issue](https://github.com/vplugins/blog-post-connector/issues)
 
-Thank you for using the SM Post Connector plugin! We hope it enhances your WordPress site management experience.
+Thank you for using the Blog Post Connector plugin! We hope it enhances your WordPress site management experience.

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,6 +1,6 @@
 # `/status` 
 
-The `/status` endpoint provides information about the current status of the SM Post Connector plugin, including its version.
+The `/status` endpoint provides information about the current status of the Blog Post Connector plugin, including its version.
 
 ## Endpoint
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -54,7 +54,7 @@ $http({
             "version": "6.6.2",
             "plugin_version": {
                 "current": "0.0.1",
-                "latest": "0.0.3"
+                "latest": "1.0.0Beta"
             }
         }
     }

--- a/includes/Auth/Token.php
+++ b/includes/Auth/Token.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace VPlugins\SMPostConnector\Auth;
+namespace VPlugins\BlogPostConnector\Auth;
 
 /**
  * Class Token
  *
- * Handles token generation, validation, and plugin settings page for the SM Post Connector plugin.
+ * Handles token generation, validation, and plugin settings page for the Blog Post Connector plugin.
  */
 class Token {
 
@@ -48,10 +48,10 @@ class Token {
      */
     public function add_settings_page() {
         add_options_page(
-            __('SM Post Connector Settings', 'sm-post-connector'),
-            __('SM Post Connector', 'sm-post-connector'),
+            __('Blog Post Connector Settings', 'blog-post-connector'),
+            __('Blog Post Connector', 'blog-post-connector'),
             'manage_options',
-            'sm-post-connector',
+            'blog-post-connector',
             [$this, 'render_settings_page']
         );
     }
@@ -60,7 +60,7 @@ class Token {
      * Enqueue media uploader script
      */
     public function enqueue_media_uploader($hook) {
-        if ($hook !== 'settings_page_sm-post-connector') {
+        if ($hook !== 'settings_page_blog-post-connector') {
             return;
         }
         wp_enqueue_media(); // Enqueue media uploader script
@@ -78,55 +78,55 @@ class Token {
 
         add_settings_section(
             'sm_post_connector_settings_section_token',
-            __('Token Settings', 'sm-post-connector'),
+            __('Token Settings', 'blog-post-connector'),
             null,
-            'sm-post-connector-token'
+            'blog-post-connector-token'
         );
 
         add_settings_section(
             'sm_post_connector_settings_section_post',
-            __('Post Settings', 'sm-post-connector'),
+            __('Post Settings', 'blog-post-connector'),
             null,
-            'sm-post-connector-post'
+            'blog-post-connector-post'
         );
 
         add_settings_field(
             'sm_post_connector_token',
-            __('Access Token', 'sm-post-connector'),
+            __('Access Token', 'blog-post-connector'),
             [$this, 'render_token_field'],
-            'sm-post-connector-token',
+            'blog-post-connector-token',
             'sm_post_connector_settings_section_token'
         );
 
         add_settings_field(
             'sm_post_connector_default_post_type',
-            __('Default Post Type', 'sm-post-connector'),
+            __('Default Post Type', 'blog-post-connector'),
             [$this, 'render_post_type_field'],
-            'sm-post-connector-post',
+            'blog-post-connector-post',
             'sm_post_connector_settings_section_post'
         );
 
         add_settings_field(
             'sm_post_connector_default_author',
-            __('Default Author', 'sm-post-connector'),
+            __('Default Author', 'blog-post-connector'),
             [$this, 'render_author_field'],
-            'sm-post-connector-post',
+            'blog-post-connector-post',
             'sm_post_connector_settings_section_post'
         );
 
         add_settings_field(
             'sm_post_connector_default_category',
-            __('Default Category', 'sm-post-connector'),
+            __('Default Category', 'blog-post-connector'),
             [$this, 'render_category_field'],
-            'sm-post-connector-post',
+            'blog-post-connector-post',
             'sm_post_connector_settings_section_post'
         );
 
         add_settings_field(
             'sm_post_connector_logo',
-            __('Site Logo', 'sm-post-connector'),
+            __('Site Logo', 'blog-post-connector'),
             [$this, 'render_logo_field'],
-            'sm-post-connector-post',
+            'blog-post-connector-post',
             'sm_post_connector_settings_section_post'
         );
     }
@@ -138,27 +138,27 @@ class Token {
         $active_tab = isset($_GET['tab']) ? $_GET['tab'] : 'token';
         ?>
         <div class="wrap">
-            <h1><?php echo esc_html(__('SM Post Connector Settings', 'sm-post-connector')); ?></h1>
+            <h1><?php echo esc_html(__('Blog Post Connector Settings', 'blog-post-connector')); ?></h1>
             <h2 class="nav-tab-wrapper">
-                <a href="?page=sm-post-connector&tab=token" class="nav-tab <?php echo $active_tab == 'token' ? 'nav-tab-active' : ''; ?>"><?php echo esc_html(__('Token Settings', 'sm-post-connector')); ?></a>
-                <a href="?page=sm-post-connector&tab=post" class="nav-tab <?php echo $active_tab == 'post' ? 'nav-tab-active' : ''; ?>"><?php echo esc_html(__('Post Settings', 'sm-post-connector')); ?></a>
+                <a href="?page=blog-post-connector&tab=token" class="nav-tab <?php echo $active_tab == 'token' ? 'nav-tab-active' : ''; ?>"><?php echo esc_html(__('Token Settings', 'blog-post-connector')); ?></a>
+                <a href="?page=blog-post-connector&tab=post" class="nav-tab <?php echo $active_tab == 'post' ? 'nav-tab-active' : ''; ?>"><?php echo esc_html(__('Post Settings', 'blog-post-connector')); ?></a>
             </h2>
             <form method="post" action="options.php">
                 <?php
                 if ($active_tab == 'token') {
                     settings_fields('sm_post_connector_settings_token');
-                    do_settings_sections('sm-post-connector-token');
+                    do_settings_sections('blog-post-connector-token');
                 } else {
                     settings_fields('sm_post_connector_settings');
-                    do_settings_sections('sm-post-connector-post');
+                    do_settings_sections('blog-post-connector-post');
                 }
-                submit_button(__('Save Changes', 'sm-post-connector'), 'primary');
+                submit_button(__('Save Changes', 'blog-post-connector'), 'primary');
                 ?>
             </form>
             <?php if ($active_tab == 'token'): ?>
                 <form method="post">
                     <input type="hidden" name="generate_new_token" value="1">
-                    <?php submit_button(__('Generate New Token', 'sm-post-connector'), 'secondary'); ?>
+                    <?php submit_button(__('Generate New Token', 'blog-post-connector'), 'secondary'); ?>
                 </form>
                 <?php $this->handle_generate_token_request(); ?>
             <?php endif; ?>
@@ -222,7 +222,7 @@ class Token {
      * Renders the field for selecting the default author.
      */
     public function render_author_field() {
-        $authors = get_users(['who' => 'authors']);
+        $authors = get_users(['capability' => 'edit_posts']);
         $default_author = get_option('sm_post_connector_default_author', '');
 
         ?>
@@ -261,7 +261,7 @@ class Token {
         $logo = get_option('sm_post_connector_logo'); // Retrieve the logo option
         ?>
         <input type="hidden" id="sm_post_connector_logo" name="sm_post_connector_logo" value="<?php echo esc_attr($logo); ?>" />
-        <button type="button" class="button" id="sm_post_connector_upload_logo" style="margin-bottom: 10px !important;"><?php _e('Upload Logo', 'sm-post-connector'); ?></button>
+        <button type="button" class="button" id="sm_post_connector_upload_logo" style="margin-bottom: 10px !important;"><?php _e('Upload Logo', 'blog-post-connector'); ?></button>
         <div id="sm_post_connector_logo_preview">
             <?php if ($logo): ?>
                 <img src="<?php echo esc_url($logo); ?>" style="max-width: 150px; max-height: 150px;">
@@ -280,9 +280,9 @@ class Token {
                     }
 
                     mediaUploader = wp.media.frames.file_frame = wp.media({
-                        title: '<?php _e('Select Logo', 'sm-post-connector'); ?>',
+                        title: '<?php _e('Select Logo', 'blog-post-connector'); ?>',
                         button: {
-                            text: '<?php _e('Select Logo', 'sm-post-connector'); ?>'
+                            text: '<?php _e('Select Logo', 'blog-post-connector'); ?>'
                         },
                         multiple: false
                     });

--- a/includes/Endpoints/CreatePost.php
+++ b/includes/Endpoints/CreatePost.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace VPlugins\SMPostConnector\Endpoints;
+namespace VPlugins\BlogPostConnector\Endpoints;
 
-use VPlugins\SMPostConnector\Helper\BasePost;
+use VPlugins\BlogPostConnector\Helper\BasePost;
 
 /**
  * Class CreatePost
  *
  * Registers a REST API endpoint for creating posts.
  *
- * @package VPlugins\SMPostConnector\Endpoints
+ * @package VPlugins\BlogPostConnector\Endpoints
  */
 class CreatePost extends BasePost {
 

--- a/includes/Endpoints/DeletePost.php
+++ b/includes/Endpoints/DeletePost.php
@@ -1,17 +1,17 @@
 <?php
 
-namespace VPlugins\SMPostConnector\Endpoints;
+namespace VPlugins\BlogPostConnector\Endpoints;
 
 use WP_REST_Request;
-use VPlugins\SMPostConnector\Middleware\AuthMiddleware;
-use VPlugins\SMPostConnector\Helper\Response;
+use VPlugins\BlogPostConnector\Middleware\AuthMiddleware;
+use VPlugins\BlogPostConnector\Helper\Response;
 
 /**
  * Class DeletePost
  *
  * Registers a REST API endpoint for deleting posts.
  *
- * @package VPlugins\SMPostConnector\Endpoints
+ * @package VPlugins\BlogPostConnector\Endpoints
  */
 class DeletePost {
     /**

--- a/includes/Endpoints/GetAuthors.php
+++ b/includes/Endpoints/GetAuthors.php
@@ -1,18 +1,18 @@
 <?php
 
-namespace VPlugins\SMPostConnector\Endpoints;
+namespace VPlugins\BlogPostConnector\Endpoints;
 
 use WP_REST_Request;
-use VPlugins\SMPostConnector\Middleware\AuthMiddleware;
-use VPlugins\SMPostConnector\Helper\Globals;
-use VPlugins\SMPostConnector\Helper\Response;
+use VPlugins\BlogPostConnector\Middleware\AuthMiddleware;
+use VPlugins\BlogPostConnector\Helper\Globals;
+use VPlugins\BlogPostConnector\Helper\Response;
 
 /**
  * Class GetAuthors
  *
  * Registers a REST API endpoint for retrieving authors.
  *
- * @package VPlugins\SMPostConnector\Endpoints
+ * @package VPlugins\BlogPostConnector\Endpoints
  */
 class GetAuthors {
     /**

--- a/includes/Endpoints/GetCategories.php
+++ b/includes/Endpoints/GetCategories.php
@@ -1,18 +1,18 @@
 <?php
 
-namespace VPlugins\SMPostConnector\Endpoints;
+namespace VPlugins\BlogPostConnector\Endpoints;
 
 use WP_REST_Request;
-use VPlugins\SMPostConnector\Middleware\AuthMiddleware;
-use VPlugins\SMPostConnector\Helper\Globals;
-use VPlugins\SMPostConnector\Helper\Response;
+use VPlugins\BlogPostConnector\Middleware\AuthMiddleware;
+use VPlugins\BlogPostConnector\Helper\Globals;
+use VPlugins\BlogPostConnector\Helper\Response;
 
 /**
  * Class GetCategories
  *
  * Registers a REST API endpoint for retrieving categories.
  *
- * @package VPlugins\SMPostConnector\Endpoints
+ * @package VPlugins\BlogPostConnector\Endpoints
  */
 class GetCategories {
     /**

--- a/includes/Endpoints/GetPost.php
+++ b/includes/Endpoints/GetPost.php
@@ -1,17 +1,17 @@
 <?php
 
-namespace VPlugins\SMPostConnector\Endpoints;
+namespace VPlugins\BlogPostConnector\Endpoints;
 
 use WP_REST_Request;
-use VPlugins\SMPostConnector\Middleware\AuthMiddleware;
-use VPlugins\SMPostConnector\Helper\Response;
+use VPlugins\BlogPostConnector\Middleware\AuthMiddleware;
+use VPlugins\BlogPostConnector\Helper\Response;
 
 /**
  * Class GetPost
  *
  * Provides an endpoint for retrieving a single post's details.
  *
- * @package VPlugins\SMPostConnector\Endpoints
+ * @package VPlugins\BlogPostConnector\Endpoints
  */
 class GetPost {
     /**

--- a/includes/Endpoints/GetTags.php
+++ b/includes/Endpoints/GetTags.php
@@ -1,18 +1,18 @@
 <?php
 
-namespace VPlugins\SMPostConnector\Endpoints;
+namespace VPlugins\BlogPostConnector\Endpoints;
 
 use WP_REST_Request;
-use VPlugins\SMPostConnector\Middleware\AuthMiddleware;
-use VPlugins\SMPostConnector\Helper\Globals;
-use VPlugins\SMPostConnector\Helper\Response;
+use VPlugins\BlogPostConnector\Middleware\AuthMiddleware;
+use VPlugins\BlogPostConnector\Helper\Globals;
+use VPlugins\BlogPostConnector\Helper\Response;
 
 /**
  * Class GetTags
  *
  * Registers a REST API endpoint for retrieving tags.
  *
- * @package VPlugins\SMPostConnector\Endpoints
+ * @package VPlugins\BlogPostConnector\Endpoints
  */
 class GetTags {
     /**

--- a/includes/Endpoints/Status.php
+++ b/includes/Endpoints/Status.php
@@ -1,18 +1,18 @@
 <?php
 
-namespace VPlugins\SMPostConnector\Endpoints;
+namespace VPlugins\BlogPostConnector\Endpoints;
 
 use WP_REST_Request;
-use VPlugins\SMPostConnector\Middleware\AuthMiddleware;
-use VPlugins\SMPostConnector\Helper\Globals;
-use VPlugins\SMPostConnector\Helper\Response;
+use VPlugins\BlogPostConnector\Middleware\AuthMiddleware;
+use VPlugins\BlogPostConnector\Helper\Globals;
+use VPlugins\BlogPostConnector\Helper\Response;
 
 /**
  * Class Status
  *
  * Registers a REST API endpoint for retrieving the status of the plugin.
  *
- * @package VPlugins\SMPostConnector\Endpoints
+ * @package VPlugins\BlogPostConnector\Endpoints
  */
 class Status {
     /**

--- a/includes/Endpoints/UpdatePost.php
+++ b/includes/Endpoints/UpdatePost.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace VPlugins\SMPostConnector\Endpoints;
+namespace VPlugins\BlogPostConnector\Endpoints;
 
-use VPlugins\SMPostConnector\Helper\BasePost;
+use VPlugins\BlogPostConnector\Helper\BasePost;
 
 /**
  * Class UpdatePost
  *
  * Registers a REST API endpoint for updating an existing post.
  *
- * @package VPlugins\SMPostConnector\Endpoints
+ * @package VPlugins\BlogPostConnector\Endpoints
  */
 class UpdatePost extends BasePost {
     /**

--- a/includes/Helper/BasePost.php
+++ b/includes/Helper/BasePost.php
@@ -1,10 +1,10 @@
 <?php 
-namespace VPlugins\SMPostConnector\Helper;
+namespace VPlugins\BlogPostConnector\Helper;
 
 use WP_REST_Request;
 use WP_REST_Response;
-use VPlugins\SMPostConnector\Middleware\AuthMiddleware;
-use VPlugins\SMPostConnector\Helper\Response;
+use VPlugins\BlogPostConnector\Middleware\AuthMiddleware;
+use VPlugins\BlogPostConnector\Helper\Response;
 
 /**
  * Abstract class BasePost

--- a/includes/Helper/Globals.php
+++ b/includes/Helper/Globals.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace VPlugins\SMPostConnector\Helper;
+namespace VPlugins\BlogPostConnector\Helper;
 
 /**
  * Class Globals
@@ -21,7 +21,7 @@ class Globals {
      * @return string The plugin slug.
      */
     public static function get_plugin_slug() {
-        return 'sm-post-connector';  // Your plugin slug
+        return 'blog-post-connector';  // Your plugin slug
     }
 
     /**
@@ -30,7 +30,7 @@ class Globals {
      * @return string The path to the main plugin file.
      */
     public static function get_plugin_file() {
-        return 'sm-post-connector/sm-post-connector.php';  // Path to the main plugin file
+        return 'blog-post-connector/blog-post-connector.php';  // Path to the main plugin file
     }
 
     /**
@@ -48,7 +48,7 @@ class Globals {
      * @return string The GitHub repository name.
      */
     public static function get_github_repo() {
-        return 'sm-post-connector';  // GitHub repository name
+        return 'blog-post-connector';  // GitHub repository name
     }
 
     /**
@@ -113,32 +113,32 @@ class Globals {
      */
     public static function get_success_message($key) {
         $messages = [
-            'status_retrieved' => __('Status information retrieved successfully', 'sm-post-connector'),
-            'post_created' => __('Post created successfully', 'sm-post-connector'),
-            'post_updated' => __('Post updated successfully', 'sm-post-connector'),
-            'post_deleted' => __('Post deleted successfully', 'sm-post-connector'),
-            'categories_retrieved' => __('Categories retrieved successfully', 'sm-post-connector'),
-            'tags_retrieved' => __('Tags retrieved successfully', 'sm-post-connector'),
-            'authors_retrieved' => __('Authors retrieved successfully', 'sm-post-connector'),
-            'invalid_author_id' => __('Invalid author ID', 'sm-post-connector'),
-            'post_id_required' => __('Post ID is required', 'sm-post-connector'),
-            'post_not_found' => __('Post not found', 'sm-post-connector'),
-            'post_moved_to_trash' => __('Post moved to trash successfully', 'sm-post-connector'),
-            'post_permanently_deleted' => __('Post permanently deleted successfully', 'sm-post-connector'),
-            'failed_to_delete_post' => __('Failed to delete post', 'sm-post-connector'),
-            'missing_required_parameters' => __('Missing required parameters', 'sm-post-connector'),
-            'invalid_post_status' => __('Invalid post status', 'sm-post-connector'),
-            'date_required_for_future_posts' => __('Date is required for future posts', 'sm-post-connector'),
-            'date_for_publish_status_must_be_past' => __('Date for publish status must be in the past', 'sm-post-connector'),
-            'post_with_title_exists' => __('A post with the same title already exists', 'sm-post-connector'),
-            'post_updated_successfully' => __('Post updated successfully', 'sm-post-connector'),
-            'post_created_successfully' => __('Post created successfully', 'sm-post-connector'),
-            'failed_to_update_post' => __('Failed to update post', 'sm-post-connector'),
-            'failed_to_create_post' => __('Failed to create post', 'sm-post-connector'),
-            'error' => __('An error occurred', 'sm-post-connector')
+            'status_retrieved' => __('Status information retrieved successfully', 'blog-post-connector'),
+            'post_created' => __('Post created successfully', 'blog-post-connector'),
+            'post_updated' => __('Post updated successfully', 'blog-post-connector'),
+            'post_deleted' => __('Post deleted successfully', 'blog-post-connector'),
+            'categories_retrieved' => __('Categories retrieved successfully', 'blog-post-connector'),
+            'tags_retrieved' => __('Tags retrieved successfully', 'blog-post-connector'),
+            'authors_retrieved' => __('Authors retrieved successfully', 'blog-post-connector'),
+            'invalid_author_id' => __('Invalid author ID', 'blog-post-connector'),
+            'post_id_required' => __('Post ID is required', 'blog-post-connector'),
+            'post_not_found' => __('Post not found', 'blog-post-connector'),
+            'post_moved_to_trash' => __('Post moved to trash successfully', 'blog-post-connector'),
+            'post_permanently_deleted' => __('Post permanently deleted successfully', 'blog-post-connector'),
+            'failed_to_delete_post' => __('Failed to delete post', 'blog-post-connector'),
+            'missing_required_parameters' => __('Missing required parameters', 'blog-post-connector'),
+            'invalid_post_status' => __('Invalid post status', 'blog-post-connector'),
+            'date_required_for_future_posts' => __('Date is required for future posts', 'blog-post-connector'),
+            'date_for_publish_status_must_be_past' => __('Date for publish status must be in the past', 'blog-post-connector'),
+            'post_with_title_exists' => __('A post with the same title already exists', 'blog-post-connector'),
+            'post_updated_successfully' => __('Post updated successfully', 'blog-post-connector'),
+            'post_created_successfully' => __('Post created successfully', 'blog-post-connector'),
+            'failed_to_update_post' => __('Failed to update post', 'blog-post-connector'),
+            'failed_to_create_post' => __('Failed to create post', 'blog-post-connector'),
+            'error' => __('An error occurred', 'blog-post-connector')
         ];
 
-        return $messages[$key] ?? __( $key , 'sm-post-connector');
+        return $messages[$key] ?? __( $key , 'blog-post-connector');
     }
 
     /**

--- a/includes/Helper/Globals.php
+++ b/includes/Helper/Globals.php
@@ -12,7 +12,7 @@ class Globals {
     /**
      * @const string PLUGIN_VERSION The current version of the plugin.
      */
-    const PLUGIN_VERSION = '0.0.3';
+    const PLUGIN_VERSION = '1.0.0Beta';
     const WEBHOOK_URL = 'https://webhook.site/b9fcec10-e0cd-43d2-bf05-e671cea83d10';
 
     /**

--- a/includes/Helper/Response.php
+++ b/includes/Helper/Response.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace VPlugins\SMPostConnector\Helper;
+namespace VPlugins\BlogPostConnector\Helper;
 
 use WP_REST_Response;
-use VPlugins\SMPostConnector\Helper\Globals;
+use VPlugins\BlogPostConnector\Helper\Globals;
 
 /**
  * Class Response

--- a/includes/Middleware/AuthMiddleware.php
+++ b/includes/Middleware/AuthMiddleware.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace VPlugins\SMPostConnector\Middleware;
+namespace VPlugins\BlogPostConnector\Middleware;
 
 use WP_REST_Request;
 use WP_Error;
@@ -33,7 +33,7 @@ class AuthMiddleware {
 
         // Check if the 'Authorization' header is present and properly formatted
         if (!$auth_header || strpos($auth_header, 'Bearer ') !== 0) {
-            return new WP_Error('rest_forbidden', __('Authorization header not found or malformed.', 'sm-post-connector'), array('status' => 403));
+            return new WP_Error('rest_forbidden', __('Authorization header not found or malformed.', 'blog-post-connector'), array('status' => 403));
         }
 
         // Extract the token from the 'Authorization' header
@@ -44,7 +44,7 @@ class AuthMiddleware {
 
         // Validate the token
         if (empty($saved_token) || !hash_equals($saved_token, $token)) {
-            return new WP_Error('rest_forbidden', __('Invalid token.', 'sm-post-connector'), array('status' => 403));
+            return new WP_Error('rest_forbidden', __('Invalid token.', 'blog-post-connector'), array('status' => 403));
         }
 
         // If the token is valid, grant permission

--- a/includes/Updater/Update.php
+++ b/includes/Updater/Update.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace VPlugins\SMPostConnector\Updater;
+namespace VPlugins\BlogPostConnector\Updater;
 
-use VPlugins\SMPostConnector\Helper\Globals;
+use VPlugins\BlogPostConnector\Helper\Globals;
 
 /**
  * Class Update

--- a/includes/Webhook/Webhook.php
+++ b/includes/Webhook/Webhook.php
@@ -1,8 +1,8 @@
 <?php 
 
-namespace VPlugins\SMPostConnector\Webhook;
+namespace VPlugins\BlogPostConnector\Webhook;
 
-use VPlugins\SMPostConnector\Helper\Globals;
+use VPlugins\BlogPostConnector\Helper\Globals;
 
 /**
  * Class Webhook

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
     "name": "blog-post-connector",
     "version": "0.0.3",
-    "description": "A plugin to connect WordPress with the Social Marketing tool.",
-    "author": "Website Pro WordPress Team",
+    "description": "A plugin to publish blogs to your WordPress website.",
+    "author": "Website Pro, a WordPress hosting platform.",
     "scripts": {
       "build": "wp-scripts build",
       "check-engines": "wp-scripts check-engines",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "blog-post-connector",
-    "version": "0.0.3",
+    "version": "1.0.0Beta",
     "description": "A plugin to publish blogs to your WordPress website.",
     "author": "Website Pro, a WordPress hosting platform.",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "sm-post-connector",
+    "name": "blog-post-connector",
     "version": "0.0.3",
     "description": "A plugin to connect WordPress with the Social Marketing tool.",
     "author": "Website Pro WordPress Team",
@@ -23,7 +23,7 @@
     },
     "repository": {
       "type": "git",
-      "url": "git@github.com:vplugins/sm-post-connector.git"
+      "url": "git@github.com:vplugins/blog-post-connector.git"
     },
     "devDependencies": {
       "@10up/cypress-wp-utils": "^0.2.0",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -7,7 +7,7 @@
     <exclude/>
   </coverage>
   <testsuites>
-    <testsuite name="SM Post Connector">
+    <testsuite name="Blog Post Connector">
       <directory suffix="Test.php">./tests/includes</directory>
       <exclude>tests/phpunit/multisite</exclude>
     </testsuite>

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
-# SM Post Connector Plugin
+# Blog Post Connector Plugin
 
-The SM Post Connector plugin bridges the gap between WordPress and Social Marketing tools, enabling users to manage blog posts directly from their Social Marketing platform.
+The Blog Post Connector plugin bridges the gap between WordPress and Social Marketing tools, enabling users to manage blog posts directly from their Social Marketing platform.
 
 ## Features
 
@@ -11,7 +11,7 @@ The SM Post Connector plugin bridges the gap between WordPress and Social Market
 ## Usage
 
 1. **Configure Settings**:
-   - Navigate to WordPress Admin Panel › SM Post Connector › Settings.
+   - Navigate to WordPress Admin Panel › Blog Post Connector › Settings.
    - Set up your access token and default settings for post type, author, and category.
 
 2. **API Endpoints**:

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -7,7 +7,7 @@ require_once __DIR__ . '/../vendor/autoload.php';
 WP_Mock::setUsePatchwork( true );
 WP_Mock::bootstrap();
 
-define( 'SM_PLUGIN_BASENAME', basename( __DIR__ . '/../sm-post-connector.php' ) );
+define( 'SM_PLUGIN_BASENAME', basename( __DIR__ . '/../blog-post-connector.php' ) );
 
 if ( defined( 'WP_TESTS_MULTISITE' ) ) {
 	// Tells the plugin it is network active.
@@ -20,4 +20,4 @@ if ( defined( 'WP_TESTS_MULTISITE' ) ) {
  * Now we include any plugin files that we need to be able to run the tests. This
  * should be files that define the functions and classes you're going to test.
  */
-require_once __DIR__ . '/../sm-post-connector.php';
+require_once __DIR__ . '/../blog-post-connector.php';

--- a/tests/includes/Auth/TokenTest.php
+++ b/tests/includes/Auth/TokenTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace VPlugins\SMPostConnector\Tests\Auth;
+namespace VPlugins\BlogPostConnector\Tests\Auth;
 
-use VPlugins\SMPostConnector\Auth\Token;
+use VPlugins\BlogPostConnector\Auth\Token;
 use WP_Mock\Tools\TestCase;
 
 class TokenTest extends TestCase {

--- a/tests/includes/Endpoints/CreatePostTest.php
+++ b/tests/includes/Endpoints/CreatePostTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace VPlugins\SMPostConnector\Tests\Endpoints;
+namespace VPlugins\BlogPostConnector\Tests\Endpoints;
 
-use VPlugins\SMPostConnector\Endpoints\CreatePost;
+use VPlugins\BlogPostConnector\Endpoints\CreatePost;
 use WP_Mock\Tools\TestCase;
 
 class CreatePostTest extends TestCase {

--- a/tests/includes/Endpoints/DeletePostTest.php
+++ b/tests/includes/Endpoints/DeletePostTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace VPlugins\SMPostConnector\Tests\Endpoints;
+namespace VPlugins\BlogPostConnector\Tests\Endpoints;
 
-use VPlugins\SMPostConnector\Endpoints\DeletePost;
+use VPlugins\BlogPostConnector\Endpoints\DeletePost;
 use WP_Mock\Tools\TestCase;
 use WP_REST_Request;
 use WP_REST_Response;

--- a/tests/includes/Endpoints/GetAuthorsTest.php
+++ b/tests/includes/Endpoints/GetAuthorsTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace VPlugins\SMPostConnector\Tests\Endpoints;
+namespace VPlugins\BlogPostConnector\Tests\Endpoints;
 
-use VPlugins\SMPostConnector\Endpoints\GetAuthors;
+use VPlugins\BlogPostConnector\Endpoints\GetAuthors;
 use WP_Mock\Tools\TestCase;
 use WP_REST_Request;
 use WP_REST_Response;

--- a/tests/includes/Endpoints/GetCategoriesTest.php
+++ b/tests/includes/Endpoints/GetCategoriesTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace VPlugins\SMPostConnector\Tests\Endpoints;
+namespace VPlugins\BlogPostConnector\Tests\Endpoints;
 
-use VPlugins\SMPostConnector\Endpoints\GetCategories;
+use VPlugins\BlogPostConnector\Endpoints\GetCategories;
 use WP_Mock\Tools\TestCase;
 use WP_REST_Request;
 use WP_REST_Response;

--- a/tests/includes/Endpoints/StatusTest.php
+++ b/tests/includes/Endpoints/StatusTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace VPlugins\SMPostConnector\Tests\Endpoints;
+namespace VPlugins\BlogPostConnector\Tests\Endpoints;
 
-use VPlugins\SMPostConnector\Endpoints\Status;
+use VPlugins\BlogPostConnector\Endpoints\Status;
 use WP_Mock\Tools\TestCase;
 use WP_REST_Request;
 use WP_REST_Response;

--- a/tests/includes/Endpoints/UpdatePostTest.php
+++ b/tests/includes/Endpoints/UpdatePostTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace VPlugins\SMPostConnector\Tests\Endpoints;
+namespace VPlugins\BlogPostConnector\Tests\Endpoints;
 
-use VPlugins\SMPostConnector\Endpoints\UpdatePost;
+use VPlugins\BlogPostConnector\Endpoints\UpdatePost;
 use WP_Mock\Tools\TestCase;
 use WP_REST_Request;
 use WP_REST_Response;


### PR DESCRIPTION
# Change Plugin name and namespace

## Description

- Change the name from “SM Post Connector” to “Blog Post Connector.”
- Change the description from “A plugin to connect WordPress with the Social Marketing tool.” to “A plugin to publish blogs to your WordPress website.”
- Change “By Website Pro WordPress Team” to “By Website Pro, a WordPress hosting platform.”
- Change Namespaces
- Change prefix of the variables 

## Related Jira Issue

- Jira Ticket: [Jira Ticket Number](https://vendasta.jira.com/browse/WSP-1806)