### PR TITLE
Enhance download_image Function to Handle Dynamic Image Types and Unique File Names

### DIFF
--- a/includes/Helper/BasePost.php
+++ b/includes/Helper/BasePost.php
@@ -129,7 +129,6 @@ abstract class BasePost {
         $attachment_id = 0;
         if (!empty($featured_image_url)) {
             $image_data = $this->download_image($featured_image_url);
-            error_log(print_r($image_data, true));
             if ($image_data['status'] === 'error') {
                 return Response::error($image_data['message'], 400);
             }


### PR DESCRIPTION
- This PR enhances the download_image function in the BasePost class to support downloading images with dynamic types from URLs. The following updates have been made:
- Image Type Detection: The function now checks the Content-Type header to determine the image’s format (e.g., jpg, png, gif, webp).
Unique File Name Generation: This function generates a unique file name for each image using uniqid(), ensuring no filename conflicts.
- Supported Image Types: Supports common image types (jpeg, png, gif, webp). Returns an error for unsupported types.
- Improved Error Handling: Adds error checks for unsupported image types and failure to save the file.