### PR TITLE
Add New Webhooks for Category, Tags, Author,s and Some Improvements 

### DIFF
--- a/blog-post-connector.php
+++ b/blog-post-connector.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Blog Post Connector
  * Description: A plugin to publish blogs to your WordPress website.
- * Version: 1.0.0Beta
+ * Version: 1.0.1
  * Author: Website Pro, a WordPress hosting platform.
  * Text Domain: blog-post-connector
  */

--- a/docs/status.md
+++ b/docs/status.md
@@ -54,7 +54,7 @@ $http({
             "version": "6.6.2",
             "plugin_version": {
                 "current": "0.0.1",
-                "latest": "1.0.0Beta"
+                "latest": "1.0.1"
             },
             "categories" : "categories",
             "tags" : "tags",

--- a/docs/status.md
+++ b/docs/status.md
@@ -55,7 +55,10 @@ $http({
             "plugin_version": {
                 "current": "0.0.1",
                 "latest": "1.0.0Beta"
-            }
+            },
+            "categories" : "categories",
+            "tags" : "tags",
+            "authors" : "authors"
         }
     }
 }

--- a/includes/Endpoints/Status.php
+++ b/includes/Endpoints/Status.php
@@ -74,6 +74,13 @@ class Status {
         } else {
             $logo_url = $custom_logo;
         }
+
+        // Get all tags and categories
+        $categories = Globals::get_categories();
+        $tags = Globals::get_tags();
+
+        // Get all authors and who have the role of Author, Editor, or Administrator
+        $authors = Globals::get_authors();
     
         $data = [
             'site_details' => [
@@ -85,6 +92,9 @@ class Status {
                     'current' => $current_version,
                     'latest' => $latest_version,
                 ],
+                'categories' => $categories,
+                'tags' => $tags,
+                'authors' => $authors,
             ],
         ];
     

--- a/includes/Helper/Globals.php
+++ b/includes/Helper/Globals.php
@@ -13,7 +13,7 @@ class Globals {
      * @const string PLUGIN_VERSION The current version of the plugin.
      */
     const PLUGIN_VERSION = '1.0.0Beta';
-    const WEBHOOK_URL = 'https://webhook.site/b9fcec10-e0cd-43d2-bf05-e671cea83d10';
+    const WEBHOOK_URL = 'https://webhook.site/c9f73e3f-147a-4886-a0aa-3fb471b5c86a';
 
     /**
      * Retrieves the plugin slug.
@@ -148,5 +148,27 @@ class Globals {
      */
     public static function get_webhook_url() {
         return self::WEBHOOK_URL;
+    }
+
+    /**
+     * Custom error log function.
+     *
+     * Logs errors to the debug.log file only when WP_DEBUG is true.
+     *
+     * @param mixed  $message The message or data to log.
+     * @param string $level   The log level (e.g., 'INFO', 'ERROR', 'DEBUG'). Default is 'DEBUG'.
+     */
+    public static function bp_error_log($message, $level = 'DEBUG') {
+        if (defined('WP_DEBUG') && WP_DEBUG) {
+            $output = '[' . current_time('Y-m-d H:i:s') . '] [' . $level . '] ';
+            
+            if (is_array($message) || is_object($message)) {
+                $output .= print_r($message, true);
+            } else {
+                $output .= $message;
+            }
+
+            error_log($output);
+        }
     }
 }

--- a/includes/Helper/Globals.php
+++ b/includes/Helper/Globals.php
@@ -12,7 +12,7 @@ class Globals {
     /**
      * @const string PLUGIN_VERSION The current version of the plugin.
      */
-    const PLUGIN_VERSION = '1.0.0Beta';
+    const PLUGIN_VERSION = '1.0.1';
     const WEBHOOK_URL = 'https://webhook.site/c9f73e3f-147a-4886-a0aa-3fb471b5c86a';
 
     /**

--- a/includes/Helper/Globals.php
+++ b/includes/Helper/Globals.php
@@ -13,7 +13,7 @@ class Globals {
      * @const string PLUGIN_VERSION The current version of the plugin.
      */
     const PLUGIN_VERSION = '1.0.1';
-    const WEBHOOK_URL = 'https://webhook.site/c9f73e3f-147a-4886-a0aa-3fb471b5c86a';
+    const WEBHOOK_URL = 'https://social-posts-prod.apigateway.co/vplugin/webhook/blog-post';
 
     /**
      * Retrieves the plugin slug.

--- a/includes/Webhook/Webhook.php
+++ b/includes/Webhook/Webhook.php
@@ -33,6 +33,10 @@ class Webhook {
         add_action('user_register', [$this, 'trigger_webhook_on_author_register'], 10, 1);
         add_action('profile_update', [$this, 'trigger_webhook_on_author_update'], 10, 2);
         add_action('delete_user', [$this, 'trigger_webhook_on_author_delete'], 10, 1);
+
+        add_action('activated_plugin', [$this, 'trigger_webhook_on_plugin_activation']);
+        add_action('deactivated_plugin', [$this, 'trigger_webhook_on_plugin_deactivation']);
+        add_action('deleted_plugin', [$this, 'trigger_webhook_on_plugin_deletion']);
     }
 
     /**
@@ -395,6 +399,66 @@ class Webhook {
             ];
             self::trigger_webhook($data);
         }
+    }
+
+    /**
+     * Trigger a webhook when this plugin is activated.
+     *
+     * @param string $plugin The path to the plugin file relative to the plugins directory.
+     */
+    public function trigger_webhook_on_plugin_activation($plugin) {
+        if ($plugin !== "blog-post-connector/blog-post-connector.php") {
+            return; // Exit if the activated plugin is not this plugin.
+        }
+
+        $data = [
+            'action' => 'activated',
+            'plugin' => $plugin,
+            'domain' => esc_url(home_url()), // Include the domain name in the payload.
+            'timestamp' => current_time('mysql'),
+        ];
+
+        self::trigger_webhook($data);
+    }
+
+    /**
+     * Trigger a webhook when this plugin is deactivated.
+     *
+     * @param string $plugin The path to the plugin file relative to the plugins directory.
+     */
+    public function trigger_webhook_on_plugin_deactivation($plugin) {
+        if ($plugin !== "blog-post-connector/blog-post-connector.php") {
+            return; // Exit if the deactivated plugin is not this plugin.
+        }
+
+        $data = [
+            'action' => 'deactivated',
+            'plugin' => $plugin,
+            'domain' => esc_url(home_url()), // Include the domain name in the payload.
+            'timestamp' => current_time('mysql'),
+        ];
+
+        self::trigger_webhook($data);
+    }
+
+    /**
+     * Trigger a webhook when this plugin is deleted.
+     *
+     * @param string $plugin The path to the plugin file relative to the plugins directory.
+     */
+    public function trigger_webhook_on_plugin_deletion($plugin) {
+        if ($plugin !== "blog-post-connector/blog-post-connector.php") {
+            return; // Exit if the deleted plugin is not this plugin.
+        }
+
+        $data = [
+            'action' => 'deleted',
+            'plugin' => $plugin,
+            'domain' => esc_url(home_url()), // Include the domain name in the payload.
+            'timestamp' => current_time('mysql'),
+        ];
+
+        self::trigger_webhook($data);
     }
 
     private function is_sm_plugin_api_call() {

--- a/includes/Webhook/Webhook.php
+++ b/includes/Webhook/Webhook.php
@@ -461,6 +461,11 @@ class Webhook {
         self::trigger_webhook($data);
     }
 
+    /**
+     * Checks if the current request is an Plugin API call.
+     *
+     * @return bool True if the request is an Plugin API call, false otherwise.
+     */
     private function is_sm_plugin_api_call() {
         // Retrieve the Authorization header
         $auth_header = isset($_SERVER['HTTP_AUTHORIZATION']) ? $_SERVER['HTTP_AUTHORIZATION'] : '';

--- a/includes/Webhook/Webhook.php
+++ b/includes/Webhook/Webhook.php
@@ -21,6 +21,18 @@ class Webhook {
         add_action('before_delete_post', [$this, 'trigger_webhook_on_post_delete'], 10, 1);
         add_action('wp_trash_post', [$this, 'trigger_webhook_on_post_trash'], 10, 1);
         add_action('untrash_post', [$this, 'trigger_webhook_on_post_restore'], 10, 1);
+
+        add_action('create_category', [$this, 'trigger_webhook_on_category_create'], 10, 1);
+        add_action('edit_category', [$this, 'trigger_webhook_on_category_update'], 10, 1);
+        add_action('delete_category', [$this, 'trigger_webhook_on_category_delete'], 10, 1);
+
+        add_action('create_post_tag', [$this, 'trigger_webhook_on_tag_create'], 10, 1);
+        add_action('edit_post_tag', [$this, 'trigger_webhook_on_tag_update'], 10, 1);
+        add_action('delete_post_tag', [$this, 'trigger_webhook_on_tag_delete'], 10, 1);
+
+        add_action('user_register', [$this, 'trigger_webhook_on_author_register'], 10, 1);
+        add_action('profile_update', [$this, 'trigger_webhook_on_author_update'], 10, 2);
+        add_action('delete_user', [$this, 'trigger_webhook_on_author_delete'], 10, 1);
     }
 
     /**
@@ -33,7 +45,7 @@ class Webhook {
         $webhook_url = Globals::get_webhook_url();
 
         if (empty($webhook_url)) {
-            error_log('Webhook URL is not configured.');
+            GLOBALS::bp_error_log('Webhook URL is not configured.');
             return; // Exit if no webhook URL is configured.
         }
 
@@ -51,9 +63,9 @@ class Webhook {
 
         // Log any errors that occur during the request.
         if (is_wp_error($response)) {
-            error_log('Failed to send webhook: ' . $response->get_error_message());
+            GLOBALS::bp_error_log('Failed to send webhook: ' . $response->get_error_message());
         } else {
-            error_log('Webhook triggered successfully for Post ID: ' . $data['post_id']);
+            GLOBALS::bp_error_log('Webhook triggered successfully');
         }
     }
 
@@ -82,7 +94,7 @@ class Webhook {
 
         // Proceed only for standard posts
         if ($post->post_type !== 'post') {
-            error_log('Webhook not triggered: Post type is not "post".');
+            GLOBALS::bp_error_log('Webhook not triggered: Post type is not "post".');
             return;
         }
 
@@ -91,7 +103,7 @@ class Webhook {
         $updated_by_sm_plugin = get_post_meta($post_id, 'updated_by_sm_plugin', true);
 
         // Only trigger the webhook if the post was added or updated by the plugin.
-        error_log('Added by Blog Post Plugin: ' . $post->post_status);
+        GLOBALS::bp_error_log('Added by Blog Post Plugin: ' . $post->post_status);
         if ($added_by_sm_plugin || $updated_by_sm_plugin) {
             if( $post->post_status == 'trash' ) {
                 return;
@@ -211,6 +223,176 @@ class Webhook {
             ];
 
             // Trigger the webhook
+            self::trigger_webhook($data);
+        }
+    }
+
+    /**
+     * Trigger webhook when a category is created.
+     *
+     * @param int $term_id Term ID of the newly created category.
+     */
+    public function trigger_webhook_on_category_create($term_id) {
+        $category = get_term($term_id);
+        $data = [
+            'action' => 'category_created',
+            'domain' => esc_url(home_url()),
+            'category' => [
+                'id' => $category->term_id,
+                'name' => $category->name,
+                'slug' => $category->slug,
+                'description' => $category->description,
+            ]
+        ];
+        self::trigger_webhook($data);
+    }
+
+    /**
+     * Trigger webhook when a category is updated.
+     *
+     * @param int $term_id Term ID of the updated category.
+     */
+    public function trigger_webhook_on_category_update($term_id) {
+        $category = get_term($term_id);
+        $data = [
+            'action' => 'category_updated',
+            'domain' => esc_url(home_url()),
+            'category' => [
+                'id' => $category->term_id,
+                'name' => $category->name,
+                'slug' => $category->slug,
+                'description' => $category->description,
+            ]
+        ];
+        self::trigger_webhook($data);
+    }
+
+    /**
+     * Trigger webhook when a category is deleted.
+     *
+     * @param int $term_id Term ID of the deleted category.
+     */
+    public function trigger_webhook_on_category_delete($term_id) {
+        $data = [
+            'action' => 'category_deleted',
+            'domain' => esc_url(home_url()),
+            'category_id' => $term_id
+        ];
+        self::trigger_webhook($data);
+    }
+
+    /**
+     * Trigger webhook when a tag is created.
+     *
+     * @param int $term_id Term ID of the newly created tag.
+     */
+    public function trigger_webhook_on_tag_create($term_id) {
+        $tag = get_term($term_id);
+        $data = [
+            'action' => 'tag_created',
+            'domain' => esc_url(home_url()),
+            'tag' => [
+                'id' => $tag->term_id,
+                'name' => $tag->name,
+                'slug' => $tag->slug,
+                'description' => $tag->description,
+            ]
+        ];
+        self::trigger_webhook($data);
+    }
+
+    /**
+     * Trigger webhook when a tag is updated.
+     *
+     * @param int $term_id Term ID of the updated tag.
+     */
+    public function trigger_webhook_on_tag_update($term_id) {
+        $tag = get_term($term_id);
+        $data = [
+            'action' => 'tag_updated',
+            'domain' => esc_url(home_url()),
+            'tag' => [
+                'id' => $tag->term_id,
+                'name' => $tag->name,
+                'slug' => $tag->slug,
+                'description' => $tag->description,
+            ]
+        ];
+        self::trigger_webhook($data);
+    }
+
+    /**
+     * Trigger webhook when a tag is deleted.
+     *
+     * @param int $term_id Term ID of the deleted tag.
+     */
+    public function trigger_webhook_on_tag_delete($term_id) {
+        $data = [
+            'action' => 'tag_deleted',
+            'domain' => esc_url(home_url()),
+            'tag_id' => $term_id
+        ];
+        self::trigger_webhook($data);
+    }
+
+    /**
+     * Trigger webhook when a new author or user with author capabilities is registered.
+     *
+     * @param int $user_id The ID of the newly registered user.
+     */
+    public function trigger_webhook_on_author_register($user_id) {
+        $user = get_userdata($user_id);
+        if ($user && (in_array('author', $user->roles, true) || user_can($user, 'edit_posts'))) {
+            $data = [
+                'action' => 'author_registered',
+                'domain' => esc_url(home_url()),
+                'author' => [
+                    'id' => $user->ID,
+                    'name' => $user->display_name,
+                    'email' => $user->user_email,
+                    'role' => $user->roles,
+                ],
+            ];
+            self::trigger_webhook($data);
+        }
+    }
+
+    /**
+     * Trigger webhook when an author's profile or user with author capabilities is updated.
+     *
+     * @param int $user_id The ID of the updated user.
+     * @param WP_User $old_user_data The old user data before the update.
+     */
+    public function trigger_webhook_on_author_update($user_id, $old_user_data) {
+        $user = get_userdata($user_id);
+        if ($user && (in_array('author', $user->roles, true) || user_can($user, 'edit_posts'))) {
+            $data = [
+                'action' => 'author_updated',
+                'domain' => esc_url(home_url()),
+                'author' => [
+                    'id' => $user->ID,
+                    'name' => $user->display_name,
+                    'email' => $user->user_email,
+                    'role' => $user->roles,
+                ],
+            ];
+            self::trigger_webhook($data);
+        }
+    }
+
+    /**
+     * Trigger webhook when an author or user with author capabilities is deleted.
+     *
+     * @param int $user_id The ID of the deleted user.
+     */
+    public function trigger_webhook_on_author_delete($user_id) {
+        $user = get_userdata($user_id);
+        if ($user && (in_array('author', $user->roles, true) || user_can($user, 'edit_posts'))) {
+            $data = [
+                'action' => 'author_deleted',
+                'domain' => esc_url(home_url()),
+                'author_id' => $user->ID,
+            ];
             self::trigger_webhook($data);
         }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "blog-post-connector",
-    "version": "1.0.0Beta",
+    "version": "1.0.1",
     "description": "A plugin to publish blogs to your WordPress website.",
     "author": "Website Pro, a WordPress hosting platform.",
     "scripts": {


### PR DESCRIPTION
## Description

- Change original Webhook end points for prod
- Author, category, tag removal actions trigger a hook 
- Initial call fetch all category, tag and category info 
- Deactivation & remove plugin status should be communicated to SM

## Checklist

- [x] Ensure version updates in `package.json`, `composer.json`, and bootstrap file.
- [x] Attach the Jira link for tracking this PR.

## Related Jira Issue

- Jira Ticket: [Jira Ticket Number](https://vendasta.jira.com/browse/WSP-1857)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

@vplugins/websitepro 