### PR TITLE
Add slug parameter and PHP 8.4 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.5]
+- Added optional `slug` parameter to Create Post and Update Post endpoints for custom permalinks.
+- PHP 8.4 compatibility: hardened token validation, replaced deprecated `get_page_by_title()` with `WP_Query`, guarded `strtotime()`/`date()` and term lookups against null/false returns.
+- Updated PHPCS lint range to `7.4-8.4`.
+
 ## [1.0.4]
 - Display a warning indicating that the plugin is not compatible with WordPress Multisite installations.
 

--- a/blog-post-connector.php
+++ b/blog-post-connector.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Blog Post Connector
  * Description: A plugin to publish blogs to your WordPress website.
- * Version: 1.0.3
+ * Version: 1.0.5
  * Author: Website Pro, a WordPress hosting platform.
  * Text Domain: blog-post-connector
  */

--- a/composer.json
+++ b/composer.json
@@ -17,12 +17,12 @@
     },
     "scripts": {
         "lint": [
-        "phpcs . --runtime-set testVersion 7.4-"
+        "phpcs . --runtime-set testVersion 7.4-8.4"
         ],
         "lint-fix": [
         "phpcbf ."
         ],
-        "phpcs:compat": "vendor/bin/phpcs simple-local-avatars.php includes --standard=PHPCompatibilityWP --extensions=php --runtime-set testVersion 7.4-"
+        "phpcs:compat": "vendor/bin/phpcs includes --standard=PHPCompatibilityWP --extensions=php --runtime-set testVersion 7.4-8.4"
     },
     "minimum-stability": "dev",
     "config": {

--- a/docs/create-post.md
+++ b/docs/create-post.md
@@ -28,6 +28,7 @@ To create a new post, make a `POST` request with the required parameters include
 | status            | string | The status of the post (e.g., `publish`).    |
 | author            | int    | The ID of the author of the post.            |
 | featured_image    | string | URL of the new featured image for the post.  |
+| slug              | string | Optional. Custom permalink slug. If omitted, WordPress generates one from the title. |
 
 ### Example 
 
@@ -43,7 +44,8 @@ $http({
         title: 'Sample Title',
         content: 'Sample content',
         status: 'publish',
-        author: 1
+        author: 1,
+        slug: 'my-custom-slug'
     }
 }).then(function successCallback(response) {
     console.log('Post created:', response.data.data);

--- a/docs/update-post.md
+++ b/docs/update-post.md
@@ -30,6 +30,7 @@ To update a post, make a `POST` request with the required parameters included in
 | status           | string | The new status of the post (e.g., `publish`). | 
 | author           | int    | The ID of the author of the post.             | 
 | featured_image   | string | URL of the new featured image for the post.   | 
+| slug             | string | Optional. Custom permalink slug. If omitted, the existing slug is preserved. | 
 
 ### Example 
 
@@ -47,7 +48,8 @@ $http({
         content: 'Updated',
         status: 'publish',
         author: 1,
-        featured_image: 'https://cdn.pixabay.com/photo/2018/07/10/21/53/tournament-3529744_1280.jpg'
+        featured_image: 'https://cdn.pixabay.com/photo/2018/07/10/21/53/tournament-3529744_1280.jpg',
+        slug: 'renamed-slug'
     }
 }).then(function successCallback(response) {
     console.log('Post updated:', response.data.data);

--- a/includes/Auth/TokenManager.php
+++ b/includes/Auth/TokenManager.php
@@ -29,8 +29,8 @@ class TokenManager {
      * @return bool True if the token matches the stored token, false otherwise.
      */
     public function validate_token($token) {
-        $saved_token = get_option('sm_post_connector_token');
-        return hash_equals($saved_token, $token);
+        $saved_token = (string) get_option('sm_post_connector_token', '');
+        return !empty($saved_token) && hash_equals($saved_token, (string) $token);
     }
 
 }

--- a/includes/Helper/BasePost.php
+++ b/includes/Helper/BasePost.php
@@ -75,6 +75,7 @@ abstract class BasePost {
         $categories = $request->get_param('category');
         $tags = $request->get_param('tag');
         $featured_image_url = $request->get_param('featured_image');
+        $slug = $request->get_param('slug');
 
         $categories_array = is_string($categories)
             ? array_map('intval', array_filter(array_map('trim', explode(',', $categories))))
@@ -112,10 +113,19 @@ abstract class BasePost {
             return $response;
         }
 
-        if (!$is_update && $title && get_page_by_title($title, OBJECT, 'post')) {
-            $response = Response::error('post_with_title_exists', 400);
-            $this->logger->log($request, $response);
-            return $response;
+        if (!$is_update && $title) {
+            $existing = new \WP_Query([
+                'post_type'      => 'post',
+                'title'          => $title,
+                'posts_per_page' => 1,
+                'fields'         => 'ids',
+                'no_found_rows'  => true,
+            ]);
+            if ($existing->have_posts()) {
+                $response = Response::error('post_with_title_exists', 400);
+                $this->logger->log($request, $response);
+                return $response;
+            }
         }
 
         if (!get_user_by('ID', $author_id)) {
@@ -139,12 +149,16 @@ abstract class BasePost {
             'post_title'    => $title ? sanitize_text_field($title) : $post->post_title,
             'post_content'  => $content ? wp_kses_post($content) : $post->post_content,
             'post_status'   => $status ? $status : $post->post_status,
-            'post_date'     => ($status === 'future') ? date('Y-m-d H:i:s', strtotime($date)) : current_time('mysql'),
+            'post_date'     => ($status === 'future' && ($ts = strtotime((string) $date)) !== false) ? date('Y-m-d H:i:s', $ts) : current_time('mysql'),
             'post_author'   => $author_id,
             'post_category' => $categories_array,
             'tags_input'    => $tags_array,
             'meta_input'    => $is_update ? ['updated_by_sm_plugin' => true] : ['added_by_sm_plugin' => true]
         ];
+
+        if (!empty($slug)) {
+            $post_data['post_name'] = sanitize_title($slug);
+        }
 
         if ($is_update) {
             $post_data['ID'] = $post_id;

--- a/includes/Helper/BasePost.php
+++ b/includes/Helper/BasePost.php
@@ -107,6 +107,12 @@ abstract class BasePost {
             return $response;
         }
 
+        if ($status === 'future' && !empty($date) && strtotime((string) $date) === false) {
+            $response = Response::error('invalid_date_format', 400);
+            $this->logger->log($request, $response);
+            return $response;
+        }
+
         if ($status === 'publish' && !empty($date) && strtotime($date) > time()) {
             $response = Response::error('date_for_publish_status_must_be_past', 400);
             $this->logger->log($request, $response);

--- a/includes/Helper/BasePost.php
+++ b/includes/Helper/BasePost.php
@@ -117,6 +117,7 @@ abstract class BasePost {
             $existing = new \WP_Query([
                 'post_type'      => 'post',
                 'title'          => $title,
+                'post_status'    => get_post_stati(),
                 'posts_per_page' => 1,
                 'fields'         => 'ids',
                 'no_found_rows'  => true,

--- a/includes/Helper/Globals.php
+++ b/includes/Helper/Globals.php
@@ -129,6 +129,7 @@ class Globals {
             'missing_required_parameters' => __('Missing required parameters', 'blog-post-connector'),
             'invalid_post_status' => __('Invalid post status', 'blog-post-connector'),
             'date_required_for_future_posts' => __('Date is required for future posts', 'blog-post-connector'),
+            'invalid_date_format' => __('Invalid date format for future post', 'blog-post-connector'),
             'date_for_publish_status_must_be_past' => __('Date for publish status must be in the past', 'blog-post-connector'),
             'post_with_title_exists' => __('A post with the same title already exists', 'blog-post-connector'),
             'post_updated_successfully' => __('Post updated successfully', 'blog-post-connector'),

--- a/includes/Helper/Globals.php
+++ b/includes/Helper/Globals.php
@@ -12,7 +12,7 @@ class Globals {
     /**
      * @const string PLUGIN_VERSION The current version of the plugin.
      */
-    const PLUGIN_VERSION = '1.0.3';
+    const PLUGIN_VERSION = '1.0.5';
     const WEBHOOK_URL = 'https://social-posts-prod.apigateway.co/vplugin/webhook/blog-post';
 
     /**

--- a/includes/Webhook/Webhook.php
+++ b/includes/Webhook/Webhook.php
@@ -129,13 +129,16 @@ class Webhook {
                     'date' => $post->post_date,
                     'modified' => $post->post_modified,
                     'permalink' => get_permalink($post_id),
-                    'categories'  => array_map(function ($cat_id) {
+                    'categories'  => array_values(array_filter(array_map(function ($cat_id) {
                                         $category = get_category($cat_id);
+                                        if (!$category || is_wp_error($category)) {
+                                            return null;
+                                        }
                                         return [
                                             'id'   => $category->term_id,
                                             'name' => $category->name,
                                         ];
-                                    }, wp_get_post_categories($post_id)),
+                                    }, wp_get_post_categories($post_id)))),
                     'tags' => array_map(function ($tag) {
                                         return $tag->name;
                                     }, wp_get_post_tags($post_id)),
@@ -251,6 +254,9 @@ class Webhook {
      */
     public function trigger_webhook_on_category_create($term_id) {
         $category = get_term($term_id);
+        if (!$category || is_wp_error($category)) {
+            return;
+        }
         $data = [
             'action' => 'category_created',
             'domain' => esc_url(home_url()),
@@ -271,6 +277,9 @@ class Webhook {
      */
     public function trigger_webhook_on_category_update($term_id) {
         $category = get_term($term_id);
+        if (!$category || is_wp_error($category)) {
+            return;
+        }
         $data = [
             'action' => 'category_updated',
             'domain' => esc_url(home_url()),
@@ -305,6 +314,9 @@ class Webhook {
      */
     public function trigger_webhook_on_tag_create($term_id) {
         $tag = get_term($term_id);
+        if (!$tag || is_wp_error($tag)) {
+            return;
+        }
         $data = [
             'action' => 'tag_created',
             'domain' => esc_url(home_url()),
@@ -325,6 +337,9 @@ class Webhook {
      */
     public function trigger_webhook_on_tag_update($term_id) {
         $tag = get_term($term_id);
+        if (!$tag || is_wp_error($tag)) {
+            return;
+        }
         $data = [
             'action' => 'tag_updated',
             'domain' => esc_url(home_url()),


### PR DESCRIPTION
## Summary
- **Slug parameter**: Added optional `slug` field to Create Post and Update Post API endpoints. When provided, it is sanitized via `sanitize_title()` and set as `post_name`. When omitted, WordPress auto-derives from the title (backward compatible). Collision handling is automatic via WP core's `wp_unique_post_slug()`.
- **PHP 8.4 compatibility**: Hardened `hash_equals()` in `TokenManager` against false/null from `get_option()`, replaced deprecated `get_page_by_title()` with `WP_Query`, guarded `strtotime()`/`date()` against false return, and added null/WP_Error checks on `get_term()`/`get_category()` in Webhook handlers.
- Updated PHPCS lint range to `7.4-8.4` and fixed stray `simple-local-avatars.php` reference in `phpcs:compat` script.
- Bumped plugin version to 1.0.5.

## Files changed
| File | Change |
|------|--------|
| `includes/Helper/BasePost.php` | Slug param, `WP_Query` replacement, `strtotime` guard |
| `includes/Auth/TokenManager.php` | `hash_equals` null-safety |
| `includes/Webhook/Webhook.php` | 5x `get_term`/`get_category` null guards |
| `composer.json` | Lint `testVersion` → `7.4-8.4` |
| `blog-post-connector.php` / `includes/Helper/Globals.php` | Version → 1.0.5 |
| `docs/create-post.md` / `docs/update-post.md` | `slug` param documented |
| `CHANGELOG.md` | 1.0.5 entry |

## Test plan
- [ ] `composer lint` reports zero PHPCompatibility errors against `7.4-8.4`
- [ ] Create post with `slug: "my-custom-slug"` → permalink ends in `/my-custom-slug/`
- [ ] Create post without `slug` → permalink auto-derived from title (regression)
- [ ] Duplicate slug → WP appends `-2` automatically
- [ ] Update post with `slug: "renamed"` → permalink updates
- [ ] Raw text slug (e.g. `"My Cool Post!"`) → sanitized to `my-cool-post`
- [ ] Fresh activation, hit endpoint before generating token → 403, no TypeError
- [ ] Smoke test all endpoints on PHP 8.4 with `WP_DEBUG_LOG` — zero deprecation warnings from plugin
- [ ] Trigger category/tag create/update webhooks — no fatals on missing terms

🤖 Generated with [Claude Code](https://claude.com/claude-code)