### PR TITLE
Add webhook enable/disable API endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.6]
+- Added `/webhook/enable` and `/webhook/disable` API endpoints so Social Marketing can toggle webhook delivery for a connection without deactivating the plugin.
+- Both endpoints are idempotent and return the current webhook state (`enabled`/`disabled`).
+- Webhook delivery now checks this state before firing, preventing webhooks from continuing to fire against dead/disconnected connections.
+
 ## [1.0.5]
 - Added optional `slug` parameter to Create Post and Update Post endpoints for custom permalinks.
 - PHP 8.4 compatibility: hardened token validation, replaced deprecated `get_page_by_title()` with `WP_Query`, guarded `strtotime()`/`date()` and term lookups against null/false returns.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `/webhook/enable` and `/webhook/disable` API endpoints so Social Marketing can toggle webhook delivery for a connection without deactivating the plugin.
 - Both endpoints are idempotent and return the current webhook state (`enabled`/`disabled`).
 - Webhook delivery now checks this state before firing, preventing webhooks from continuing to fire against dead/disconnected connections.
+- Plugin lifecycle webhooks (`activated`, `deactivated`, `deleted`) are still delivered while disabled, so a muted site can be detected as available again.
+- The `/status` endpoint now reports the current webhook state as `webhook_status`.
+- Fixed the PHPUnit bootstrap, which aborted the whole suite before any test ran, and corrected a `TokenTest` mock that no longer matched `validate_token()`.
 
 ## [1.0.5]
 - Added optional `slug` parameter to Create Post and Update Post endpoints for custom permalinks.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Plugin lifecycle webhooks (`activated`, `deactivated`, `deleted`) are still delivered while disabled, so a muted site can be detected as available again.
 - The `/status` endpoint now reports the current webhook state as `webhook_status`.
 - Fixed the PHPUnit bootstrap, which aborted the whole suite before any test ran, and corrected a `TokenTest` mock that no longer matched `validate_token()`.
+- Pinned `10up/phpcs-composer` to `^3.0`; the previous `dev-master` constraint no longer satisfied the lock file and pulled a `wp-coding-standards/wpcs` release blocked by a security advisory, breaking `composer install`.
 
 ## [1.0.5]
 - Added optional `slug` parameter to Create Post and Update Post endpoints for custom permalinks.

--- a/blog-post-connector.php
+++ b/blog-post-connector.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Blog Post Connector
  * Description: A plugin to publish blogs to your WordPress website.
- * Version: 1.0.5
+ * Version: 1.0.6
  * Author: Website Pro, a WordPress hosting platform.
  * Text Domain: blog-post-connector
  */
@@ -26,7 +26,8 @@ use VPlugins\BlogPostConnector\Endpoints\{
     GetAuthors,
     GetCategories,
     GetTags,
-    Status
+    Status,
+    WebhookControl
 };
 use VPlugins\BlogPostConnector\Middleware\LoggerMiddleware;
 
@@ -56,6 +57,7 @@ class EndpointRegistry {
         SettingsPageController::class,
         GetTags::class,
         GetPost::class,
+        WebhookControl::class,
     ];
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "php": ">=7.4"
     },
     "require-dev": {
-        "10up/phpcs-composer": "dev-master",
+        "10up/phpcs-composer": "^3.0",
         "10up/wp_mock": "0.4.2",
         "yoast/phpunit-polyfills": "^1.0"
     },

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,6 +16,7 @@ Welcome to the documentation for the **Blog Post Connector** plugin. This plugin
 	- [Get Authors](get-authors.md)
 	- [Get Categories](get-categories.md)
 	- [Get Tags](get-tags.md)
+	- [Enable/Disable Webhook](webhook-control.md)
 - [FAQ](faq.md)
 - [Support](#support)
 
@@ -50,6 +51,7 @@ The Blog Post Connector plugin provides the following API endpoints:
 -  **Get Categories**: Retrieves a list of all categories. [View Details](get-categories.md)
 -  **Get Tags**: Retrieves a list of all tags. [View Details](get-tags.md)
 -  **Status**: Provides the current status of the plugin. [View Details](status.md)  
+-  **Enable/Disable Webhook**: Turns outbound webhook delivery on or off for the current connection. [View Details](webhook-control.md)
 
 ## FAQ
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -59,7 +59,17 @@ $http({
             "categories" : "categories",
             "tags" : "tags",
             "authors" : "authors"
-        }
+        },
+        "webhook_status": "enabled"
     }
 }
 ```
+
+### Response Fields
+
+| Field                  | Type   | Description                                                                                  |
+|:-----------------------|:-------|:---------------------------------------------------------------------------------------------|
+| data.site_details      | object | Site name, description, logo, WordPress version, plugin version, categories, tags and authors. |
+| data.webhook_status    | string | Whether outbound webhook delivery is currently `enabled` or `disabled`. See [Enable/Disable Webhook](webhook-control.md). |
+
+Note that `webhook_status` is a sibling of `site_details`, not nested inside it — it describes the connection rather than the site.

--- a/docs/webhook-control.md
+++ b/docs/webhook-control.md
@@ -1,0 +1,72 @@
+# `/webhook/enable` and `/webhook/disable`
+
+These endpoints turn outbound webhook delivery on and off for the current connection. Use them when a connection is no longer active on the Social Marketing side — disabling stops the plugin sending webhooks to a connection that can no longer accept them, without deactivating or uninstalling the plugin.
+
+Both endpoints are **idempotent**: calling `disable` on an already-disabled connection succeeds as a no-op, and the same is true for `enable`.
+
+## Endpoints
+
+- **URL**: `/wp-json/sm-connect/v1/webhook/enable`
+- **URL**: `/wp-json/sm-connect/v1/webhook/disable`
+- **Method**: `POST`
+- **Authentication**: Bearer Token
+- **Content-Type**: `application/json`
+
+## Request
+
+Make a `POST` request with an `Authorization` header containing a valid Bearer token. Neither endpoint takes a body or any parameters.
+
+### Request Headers
+
+| Header           | Value                                          |
+|:-----------------|:-----------------------------------------------|
+| Authorization    | `Bearer <your_access_token>`                   |
+
+## Response
+
+The response reports the resulting state in `data.webhook_status`, so the value can be logged directly.
+
+| Field                  | Type   | Description                                       |
+|:-----------------------|:-------|:--------------------------------------------------|
+| status                 | int    | HTTP status code.                                 |
+| message                | string | Human-readable result message.                    |
+| data.webhook_status    | string | Either `enabled` or `disabled`.                   |
+
+```json
+{
+    "status": 200,
+    "message": "Webhook delivery disabled",
+    "data": {
+        "webhook_status": "disabled"
+    }
+}
+```
+
+A `500` with the message `Failed to update webhook delivery state` means the new state could not be persisted. The state is verified after writing, so a `200` always reflects what is actually stored — treat any non-`200` as "state unchanged" and retry.
+
+### Example
+
+```javascript
+$http({
+    method: 'POST',
+    url: 'SITE_URL/wp-json/sm-connect/v1/webhook/disable',
+    headers: {
+        'Authorization': 'Bearer <your_access_token>',
+        'Content-Type': 'application/json'
+    }
+}).then(function successCallback(response) {
+    console.log('Webhook status:', response.data.data.webhook_status);
+}, function errorCallback(response) {
+    console.error('Error:', response.data.message);
+});
+```
+
+## Reading the current state
+
+The [Status](status.md) endpoint reports the current value as `data.webhook_status`, so the state can be read without toggling it.
+
+## What disabling does and does not stop
+
+While delivery is disabled, the plugin stops sending content webhooks — post created, updated, trashed, restored and deleted, plus category, tag and author events.
+
+Plugin **lifecycle** events (`activated`, `deactivated`, `deleted`) are still sent. These report the state of the connection itself rather than site content, and they are how Social Marketing learns that a previously muted site is available again. Note that the disabled state persists across a deactivate/reactivate cycle: re-enabling delivery always requires an explicit call to `/webhook/enable`.

--- a/includes/Endpoints/Status.php
+++ b/includes/Endpoints/Status.php
@@ -97,6 +97,7 @@ class Status {
                 'tags' => $tags,
                 'authors' => $authors,
             ],
+            'webhook_status' => Globals::is_webhook_enabled() ? 'enabled' : 'disabled',
         ];
     
         $success_message = 'Status retrieved successfully.'; // Custom message

--- a/includes/Endpoints/WebhookControl.php
+++ b/includes/Endpoints/WebhookControl.php
@@ -23,12 +23,18 @@ class WebhookControl {
     protected $auth_middleware;
 
     /**
+     * @var LoggerMiddleware
+     */
+    protected $logger;
+
+    /**
      * WebhookControl constructor.
      *
-     * Initializes the AuthMiddleware instance and registers the REST API routes.
+     * Initializes the middleware instances and registers the REST API routes.
      */
     public function __construct() {
         $this->auth_middleware = new AuthMiddleware();
+        $this->logger = new LoggerMiddleware();
         add_action('rest_api_init', [$this, 'register_routes']);
     }
 
@@ -107,10 +113,7 @@ class WebhookControl {
      * @return \WP_REST_Response
      */
     private function respond(WP_REST_Request $request, $response) {
-        if (class_exists(LoggerMiddleware::class)) {
-            $logger = new LoggerMiddleware();
-            $logger->log($request, $response);
-        }
+        $this->logger->log($request, $response);
 
         return $response;
     }

--- a/includes/Endpoints/WebhookControl.php
+++ b/includes/Endpoints/WebhookControl.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace VPlugins\BlogPostConnector\Endpoints;
+
+use WP_REST_Request;
+use VPlugins\BlogPostConnector\Middleware\AuthMiddleware;
+use VPlugins\BlogPostConnector\Helper\Response;
+use VPlugins\BlogPostConnector\Middleware\LoggerMiddleware;
+
+/**
+ * Class WebhookControl
+ *
+ * Registers REST API endpoints that let SM enable or disable webhook
+ * delivery for the current connection without deactivating the plugin.
+ *
+ * @package VPlugins\BlogPostConnector\Endpoints
+ */
+class WebhookControl {
+
+    /**
+     * @const string OPTION_NAME The option storing whether webhook delivery is enabled.
+     */
+    const OPTION_NAME = 'sm_post_connector_webhook_enabled';
+
+    /**
+     * @var AuthMiddleware
+     */
+    protected $auth_middleware;
+
+    /**
+     * WebhookControl constructor.
+     *
+     * Initializes the AuthMiddleware instance and registers the REST API routes.
+     */
+    public function __construct() {
+        $this->auth_middleware = new AuthMiddleware();
+        add_action('rest_api_init', [$this, 'register_routes']);
+    }
+
+    /**
+     * Registers the REST API routes for enabling and disabling webhook delivery.
+     *
+     * Routes are registered under the namespace 'sm-connect/v1'.
+     */
+    public function register_routes() {
+        register_rest_route('sm-connect/v1', '/webhook/enable', [
+            'methods' => 'POST',
+            'callback' => [$this, 'enable_webhook'],
+            'permission_callback' => [$this->auth_middleware, 'permissions_check']
+        ]);
+
+        register_rest_route('sm-connect/v1', '/webhook/disable', [
+            'methods' => 'POST',
+            'callback' => [$this, 'disable_webhook'],
+            'permission_callback' => [$this->auth_middleware, 'permissions_check']
+        ]);
+    }
+
+    /**
+     * Handles the request to enable webhook delivery.
+     *
+     * @param WP_REST_Request $request The incoming request.
+     * @return \WP_REST_Response The response indicating webhook delivery is enabled.
+     */
+    public function enable_webhook(WP_REST_Request $request) {
+        return $this->set_webhook_state($request, true);
+    }
+
+    /**
+     * Handles the request to disable webhook delivery.
+     *
+     * @param WP_REST_Request $request The incoming request.
+     * @return \WP_REST_Response The response indicating webhook delivery is disabled.
+     */
+    public function disable_webhook(WP_REST_Request $request) {
+        return $this->set_webhook_state($request, false);
+    }
+
+    /**
+     * Persists the desired webhook state and returns a standardized response.
+     *
+     * Writing the same value the option already holds is a no-op from the
+     * caller's perspective, which is what makes both endpoints idempotent.
+     *
+     * @param WP_REST_Request $request The incoming request, used for logging.
+     * @param bool $enabled Whether webhook delivery should be enabled.
+     * @return \WP_REST_Response
+     */
+    private function set_webhook_state(WP_REST_Request $request, $enabled) {
+        update_option(self::OPTION_NAME, $enabled ? '1' : '0');
+
+        $data = ['webhook_status' => $enabled ? 'enabled' : 'disabled'];
+        $response = Response::success($enabled ? 'webhook_enabled' : 'webhook_disabled', $data);
+
+        if (class_exists(LoggerMiddleware::class)) {
+            $logger = new LoggerMiddleware();
+            $logger->log($request, $response);
+        }
+
+        return $response;
+    }
+
+    /**
+     * Determines whether webhook delivery is currently enabled.
+     *
+     * Webhooks are enabled by default so existing connections keep working
+     * until SM explicitly disables them.
+     *
+     * @return bool True if webhook delivery is enabled, false otherwise.
+     */
+    public static function is_enabled() {
+        return get_option(self::OPTION_NAME, '1') === '1';
+    }
+}

--- a/includes/Endpoints/WebhookControl.php
+++ b/includes/Endpoints/WebhookControl.php
@@ -4,24 +4,19 @@ namespace VPlugins\BlogPostConnector\Endpoints;
 
 use WP_REST_Request;
 use VPlugins\BlogPostConnector\Middleware\AuthMiddleware;
+use VPlugins\BlogPostConnector\Helper\Globals;
 use VPlugins\BlogPostConnector\Helper\Response;
 use VPlugins\BlogPostConnector\Middleware\LoggerMiddleware;
 
 /**
  * Class WebhookControl
  *
- * Registers REST API endpoints that let SM enable or disable webhook
- * delivery for the current connection without deactivating the plugin.
+ * Registers REST API endpoints that let Social Marketing enable or disable
+ * webhook delivery for the current connection without deactivating the plugin.
  *
  * @package VPlugins\BlogPostConnector\Endpoints
  */
 class WebhookControl {
-
-    /**
-     * @const string OPTION_NAME The option storing whether webhook delivery is enabled.
-     */
-    const OPTION_NAME = 'sm_post_connector_webhook_enabled';
-
     /**
      * @var AuthMiddleware
      */
@@ -79,36 +74,44 @@ class WebhookControl {
     /**
      * Persists the desired webhook state and returns a standardized response.
      *
-     * Writing the same value the option already holds is a no-op from the
-     * caller's perspective, which is what makes both endpoints idempotent.
+     * Repeating a call is a no-op from the caller's perspective, which is what
+     * makes both endpoints idempotent. The stored state is verified after the
+     * write so a failed write is never reported as success.
      *
      * @param WP_REST_Request $request The incoming request, used for logging.
      * @param bool $enabled Whether webhook delivery should be enabled.
      * @return \WP_REST_Response
      */
     private function set_webhook_state(WP_REST_Request $request, $enabled) {
-        update_option(self::OPTION_NAME, $enabled ? '1' : '0');
+        if (!Globals::set_webhook_enabled($enabled)) {
+            return $this->respond(
+                $request,
+                Response::internal_server_error('webhook_state_update_failed')
+            );
+        }
 
-        $data = ['webhook_status' => $enabled ? 'enabled' : 'disabled'];
-        $response = Response::success($enabled ? 'webhook_enabled' : 'webhook_disabled', $data);
+        return $this->respond(
+            $request,
+            Response::success(
+                $enabled ? 'webhook_enabled' : 'webhook_disabled',
+                ['webhook_status' => $enabled ? 'enabled' : 'disabled']
+            )
+        );
+    }
 
+    /**
+     * Logs the request/response pair and returns the response.
+     *
+     * @param WP_REST_Request $request The incoming request.
+     * @param \WP_REST_Response $response The response to return.
+     * @return \WP_REST_Response
+     */
+    private function respond(WP_REST_Request $request, $response) {
         if (class_exists(LoggerMiddleware::class)) {
             $logger = new LoggerMiddleware();
             $logger->log($request, $response);
         }
 
         return $response;
-    }
-
-    /**
-     * Determines whether webhook delivery is currently enabled.
-     *
-     * Webhooks are enabled by default so existing connections keep working
-     * until SM explicitly disables them.
-     *
-     * @return bool True if webhook delivery is enabled, false otherwise.
-     */
-    public static function is_enabled() {
-        return get_option(self::OPTION_NAME, '1') === '1';
     }
 }

--- a/includes/Helper/Globals.php
+++ b/includes/Helper/Globals.php
@@ -165,10 +165,16 @@ class Globals {
      * Delivery is enabled by default so existing connections keep working
      * until Social Marketing explicitly disables them.
      *
+     * The value is cast rather than compared strictly: WordPress may hand back
+     * a boolean instead of the stored '1'/'0' string (for example when another
+     * writer used update_option() with a boolean and the in-request option
+     * cache is serving it), and a strict comparison would read that as
+     * disabled and silently mute every webhook.
+     *
      * @return bool True if webhook delivery is enabled, false otherwise.
      */
     public static function is_webhook_enabled() {
-        return get_option(self::WEBHOOK_ENABLED_OPTION, '1') === '1';
+        return (bool) get_option(self::WEBHOOK_ENABLED_OPTION, '1');
     }
 
     /**

--- a/includes/Helper/Globals.php
+++ b/includes/Helper/Globals.php
@@ -16,6 +16,11 @@ class Globals {
     const WEBHOOK_URL = 'https://social-posts-prod.apigateway.co/vplugin/webhook/blog-post';
 
     /**
+     * @const string WEBHOOK_ENABLED_OPTION The option storing whether webhook delivery is enabled.
+     */
+    const WEBHOOK_ENABLED_OPTION = 'sm_post_connector_webhook_enabled';
+
+    /**
      * Retrieves the plugin slug.
      *
      * @return string The plugin slug.
@@ -138,6 +143,7 @@ class Globals {
             'failed_to_create_post' => __('Failed to create post', 'blog-post-connector'),
             'webhook_enabled' => __('Webhook delivery enabled', 'blog-post-connector'),
             'webhook_disabled' => __('Webhook delivery disabled', 'blog-post-connector'),
+            'webhook_state_update_failed' => __('Failed to update webhook delivery state', 'blog-post-connector'),
             'error' => __('An error occurred', 'blog-post-connector')
         ];
 
@@ -151,6 +157,32 @@ class Globals {
      */
     public static function get_webhook_url() {
         return self::WEBHOOK_URL;
+    }
+
+    /**
+     * Determines whether webhook delivery is currently enabled.
+     *
+     * Delivery is enabled by default so existing connections keep working
+     * until Social Marketing explicitly disables them.
+     *
+     * @return bool True if webhook delivery is enabled, false otherwise.
+     */
+    public static function is_webhook_enabled() {
+        return get_option(self::WEBHOOK_ENABLED_OPTION, '1') === '1';
+    }
+
+    /**
+     * Persists whether webhook delivery is enabled.
+     *
+     * @param bool $enabled Whether webhook delivery should be enabled.
+     * @return bool True if the stored state matches the requested state after writing.
+     */
+    public static function set_webhook_enabled($enabled) {
+        update_option(self::WEBHOOK_ENABLED_OPTION, $enabled ? '1' : '0');
+
+        // update_option() also returns false when the value is unchanged, so
+        // confirm the resulting state instead of trusting its return value.
+        return self::is_webhook_enabled() === (bool) $enabled;
     }
 
     /**

--- a/includes/Helper/Globals.php
+++ b/includes/Helper/Globals.php
@@ -12,7 +12,7 @@ class Globals {
     /**
      * @const string PLUGIN_VERSION The current version of the plugin.
      */
-    const PLUGIN_VERSION = '1.0.5';
+    const PLUGIN_VERSION = '1.0.6';
     const WEBHOOK_URL = 'https://social-posts-prod.apigateway.co/vplugin/webhook/blog-post';
 
     /**
@@ -136,6 +136,8 @@ class Globals {
             'post_created_successfully' => __('Post created successfully', 'blog-post-connector'),
             'failed_to_update_post' => __('Failed to update post', 'blog-post-connector'),
             'failed_to_create_post' => __('Failed to create post', 'blog-post-connector'),
+            'webhook_enabled' => __('Webhook delivery enabled', 'blog-post-connector'),
+            'webhook_disabled' => __('Webhook delivery disabled', 'blog-post-connector'),
             'error' => __('An error occurred', 'blog-post-connector')
         ];
 

--- a/includes/Webhook/Webhook.php
+++ b/includes/Webhook/Webhook.php
@@ -63,12 +63,17 @@ class Webhook {
         }
 
         // Set up the request arguments, including headers and payload.
+        // Forced sends run while delivery is disabled, i.e. against an endpoint
+        // Social Marketing has already told us is unreachable, and fire during
+        // plugin activation/deactivation. Send those without blocking so a dead
+        // endpoint cannot stall the admin request.
         $args = [
-            'body'    => json_encode($data),
-            'headers' => [
+            'body'     => json_encode($data),
+            'headers'  => [
                 'Content-Type' => 'application/json',
             ],
-            'timeout' => 10, // Set a reasonable timeout for the request.
+            'timeout'  => $force ? 3 : 10, // Set a reasonable timeout for the request.
+            'blocking' => !$force,
         ];
 
         // Send the POST request to the specified webhook URL.

--- a/includes/Webhook/Webhook.php
+++ b/includes/Webhook/Webhook.php
@@ -3,7 +3,6 @@
 namespace VPlugins\BlogPostConnector\Webhook;
 
 use VPlugins\BlogPostConnector\Helper\Globals;
-use VPlugins\BlogPostConnector\Endpoints\WebhookControl;
 
 /**
  * Class Webhook
@@ -44,11 +43,15 @@ class Webhook {
      * Sends a POST request to the specified webhook URL.
      *
      * @param array $data The data to send in the webhook payload.
+     * @param bool $force Whether to send even when webhook delivery is disabled.
+     *                    Reserved for plugin lifecycle events, which report the
+     *                    connection's own state and are how Social Marketing
+     *                    learns a muted site is available again.
      * @return void
      */
-    public static function trigger_webhook($data = []) {
-        if (!WebhookControl::is_enabled()) {
-            GLOBALS::bp_error_log('Webhook not triggered: webhook delivery is disabled.');
+    public static function trigger_webhook($data = [], $force = false) {
+        if (!$force && !Globals::is_webhook_enabled()) {
+            Globals::bp_error_log('Webhook not triggered: webhook delivery is disabled.');
             return; // Exit if webhook delivery has been disabled by SM.
         }
 
@@ -452,7 +455,9 @@ class Webhook {
             'timestamp' => current_time('mysql'),
         ];
 
-        self::trigger_webhook($data);
+        // Sent even while delivery is disabled so Social Marketing can tell a
+        // muted site is back and decide whether to re-enable delivery.
+        self::trigger_webhook($data, true);
     }
 
     /**
@@ -472,7 +477,9 @@ class Webhook {
             'timestamp' => current_time('mysql'),
         ];
 
-        self::trigger_webhook($data);
+        // Lifecycle events report the connection's own state, so they are sent
+        // even while delivery is disabled.
+        self::trigger_webhook($data, true);
     }
 
     /**
@@ -492,7 +499,9 @@ class Webhook {
             'timestamp' => current_time('mysql'),
         ];
 
-        self::trigger_webhook($data);
+        // Lifecycle events report the connection's own state, so they are sent
+        // even while delivery is disabled.
+        self::trigger_webhook($data, true);
     }
 
     /**

--- a/includes/Webhook/Webhook.php
+++ b/includes/Webhook/Webhook.php
@@ -3,6 +3,7 @@
 namespace VPlugins\BlogPostConnector\Webhook;
 
 use VPlugins\BlogPostConnector\Helper\Globals;
+use VPlugins\BlogPostConnector\Endpoints\WebhookControl;
 
 /**
  * Class Webhook
@@ -46,6 +47,11 @@ class Webhook {
      * @return void
      */
     public static function trigger_webhook($data = []) {
+        if (!WebhookControl::is_enabled()) {
+            GLOBALS::bp_error_log('Webhook not triggered: webhook delivery is disabled.');
+            return; // Exit if webhook delivery has been disabled by SM.
+        }
+
         $webhook_url = Globals::get_webhook_url();
 
         if (empty($webhook_url)) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "blog-post-connector",
-    "version": "1.0.3",
+    "version": "1.0.6",
     "description": "A plugin to publish blogs to your WordPress website.",
     "author": "Website Pro, a WordPress hosting platform.",
     "scripts": {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -17,7 +17,33 @@ if ( defined( 'WP_TESTS_MULTISITE' ) ) {
 }
 
 /**
- * Now we include any plugin files that we need to be able to run the tests. This
- * should be files that define the functions and classes you're going to test.
+ * WP_Mock ships no WordPress classes, so stub the few the plugin constructs
+ * directly. Only classes are stubbed here, never functions -- functions must
+ * stay undefined so tests can mock them via WP_Mock::userFunction().
  */
-require_once __DIR__ . '/../blog-post-connector.php';
+if ( ! class_exists( 'WP_REST_Response' ) ) {
+	class WP_REST_Response {
+		protected $data;
+		protected $status;
+
+		public function __construct( $data = null, $status = 200 ) {
+			$this->data   = $data;
+			$this->status = $status;
+		}
+
+		public function get_data() {
+			return $this->data;
+		}
+
+		public function get_status() {
+			return $this->status;
+		}
+	}
+}
+
+/**
+ * The plugin's classes are all reachable through Composer's PSR-4 autoloader,
+ * so the main plugin file is deliberately not required here: it calls
+ * register_activation_hook() and other WordPress functions at the top level,
+ * which WP_Mock does not define, and requiring it aborts the whole run.
+ */

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -21,6 +21,10 @@ if ( defined( 'WP_TESTS_MULTISITE' ) ) {
  * directly. Only classes are stubbed here, never functions -- functions must
  * stay undefined so tests can mock them via WP_Mock::userFunction().
  */
+if ( ! class_exists( 'WP_REST_Request' ) ) {
+	class WP_REST_Request {}
+}
+
 if ( ! class_exists( 'WP_REST_Response' ) ) {
 	class WP_REST_Response {
 		protected $data;

--- a/tests/includes/Auth/TokenTest.php
+++ b/tests/includes/Auth/TokenTest.php
@@ -23,7 +23,7 @@ class TokenTest extends TestCase {
         
         // Mock the get_option function to return a specific token
         \WP_Mock::userFunction('get_option', [
-            'args' => ['sm_post_connector_token'],
+            'args' => ['sm_post_connector_token', ''],
             'return' => $test_token
         ]);
 

--- a/tests/includes/Endpoints/WebhookControlTest.php
+++ b/tests/includes/Endpoints/WebhookControlTest.php
@@ -3,6 +3,7 @@
 namespace VPlugins\BlogPostConnector\Tests\Endpoints;
 
 use VPlugins\BlogPostConnector\Endpoints\WebhookControl;
+use VPlugins\BlogPostConnector\Helper\Globals;
 use WP_Mock\Tools\TestCase;
 use WP_REST_Request;
 
@@ -27,6 +28,30 @@ class WebhookControlTest extends TestCase {
     public function tearDown(): void {
         \WP_Mock::tearDown();
         parent::tearDown();
+    }
+
+    /**
+     * Mocks get_option so the webhook flag reads back as $stored and logging stays off.
+     *
+     * @param string $stored The value the webhook option should read back as.
+     */
+    private function mock_get_option($stored) {
+        \WP_Mock::userFunction('get_option', [
+            'return' => function ($name, $default = null) use ($stored) {
+                if ($name === Globals::WEBHOOK_ENABLED_OPTION) {
+                    return $stored;
+                }
+
+                return false; // Keeps LoggerMiddleware inert.
+            },
+        ]);
+    }
+
+    /**
+     * Returns a stand-in request object for the endpoint callbacks.
+     */
+    private function mock_request() {
+        return \Mockery::mock(WP_REST_Request::class);
     }
 
     /**
@@ -70,22 +95,12 @@ class WebhookControlTest extends TestCase {
     public function test_enable_webhook_sets_option_and_returns_enabled_status() {
         \WP_Mock::userFunction('update_option', [
             'times' => 1,
-            'args' => [WebhookControl::OPTION_NAME, '1'],
+            'args' => [Globals::WEBHOOK_ENABLED_OPTION, '1'],
             'return' => true,
         ]);
-        \WP_Mock::userFunction('get_option', [
-            'args' => ['sm_post_connector_enable_logs'],
-            'return' => false,
-        ]);
-        \WP_Mock::userFunction('__', [
-            'return' => function ($text) {
-                return $text;
-            },
-        ]);
+        $this->mock_get_option('1');
 
-        $request = \Mockery::mock(WP_REST_Request::class);
-
-        $response = $this->webhookControl->enable_webhook($request);
+        $response = $this->webhookControl->enable_webhook($this->mock_request());
 
         $this->assertEquals(200, $response->get_status());
         $this->assertEquals('enabled', $response->get_data()['data']['webhook_status']);
@@ -97,22 +112,12 @@ class WebhookControlTest extends TestCase {
     public function test_disable_webhook_sets_option_and_returns_disabled_status() {
         \WP_Mock::userFunction('update_option', [
             'times' => 1,
-            'args' => [WebhookControl::OPTION_NAME, '0'],
+            'args' => [Globals::WEBHOOK_ENABLED_OPTION, '0'],
             'return' => true,
         ]);
-        \WP_Mock::userFunction('get_option', [
-            'args' => ['sm_post_connector_enable_logs'],
-            'return' => false,
-        ]);
-        \WP_Mock::userFunction('__', [
-            'return' => function ($text) {
-                return $text;
-            },
-        ]);
+        $this->mock_get_option('0');
 
-        $request = \Mockery::mock(WP_REST_Request::class);
-
-        $response = $this->webhookControl->disable_webhook($request);
+        $response = $this->webhookControl->disable_webhook($this->mock_request());
 
         $this->assertEquals(200, $response->get_status());
         $this->assertEquals('disabled', $response->get_data()['data']['webhook_status']);
@@ -120,27 +125,20 @@ class WebhookControlTest extends TestCase {
 
     /**
      * Test that repeated calls to disable an already-disabled webhook remain a success no-op.
+     *
+     * update_option() returns false when the value is unchanged, which must not
+     * be mistaken for a failed write.
      */
     public function test_disable_webhook_is_idempotent() {
         \WP_Mock::userFunction('update_option', [
             'times' => 2,
-            'args' => [WebhookControl::OPTION_NAME, '0'],
-            'return' => true,
+            'args' => [Globals::WEBHOOK_ENABLED_OPTION, '0'],
+            'return' => false, // Unchanged value.
         ]);
-        \WP_Mock::userFunction('get_option', [
-            'args' => ['sm_post_connector_enable_logs'],
-            'return' => false,
-        ]);
-        \WP_Mock::userFunction('__', [
-            'return' => function ($text) {
-                return $text;
-            },
-        ]);
+        $this->mock_get_option('0');
 
-        $request = \Mockery::mock(WP_REST_Request::class);
-
-        $first = $this->webhookControl->disable_webhook($request);
-        $second = $this->webhookControl->disable_webhook($request);
+        $first = $this->webhookControl->disable_webhook($this->mock_request());
+        $second = $this->webhookControl->disable_webhook($this->mock_request());
 
         $this->assertEquals(200, $first->get_status());
         $this->assertEquals(200, $second->get_status());
@@ -149,26 +147,18 @@ class WebhookControlTest extends TestCase {
     }
 
     /**
-     * Test that is_enabled() defaults to true when the option has never been set.
+     * Test that a write which does not land is reported as an error rather than success.
      */
-    public function test_is_enabled_defaults_to_true() {
-        \WP_Mock::userFunction('get_option', [
-            'args' => [WebhookControl::OPTION_NAME, '1'],
-            'return' => '1',
+    public function test_disable_webhook_reports_error_when_write_does_not_persist() {
+        \WP_Mock::userFunction('update_option', [
+            'times' => 1,
+            'args' => [Globals::WEBHOOK_ENABLED_OPTION, '0'],
+            'return' => false,
         ]);
+        $this->mock_get_option('1'); // Still enabled: the write did not stick.
 
-        $this->assertTrue(WebhookControl::is_enabled());
-    }
+        $response = $this->webhookControl->disable_webhook($this->mock_request());
 
-    /**
-     * Test that is_enabled() reflects a persisted disabled state.
-     */
-    public function test_is_enabled_reflects_disabled_option() {
-        \WP_Mock::userFunction('get_option', [
-            'args' => [WebhookControl::OPTION_NAME, '1'],
-            'return' => '0',
-        ]);
-
-        $this->assertFalse(WebhookControl::is_enabled());
+        $this->assertEquals(500, $response->get_status());
     }
 }

--- a/tests/includes/Endpoints/WebhookControlTest.php
+++ b/tests/includes/Endpoints/WebhookControlTest.php
@@ -1,0 +1,174 @@
+<?php
+
+namespace VPlugins\BlogPostConnector\Tests\Endpoints;
+
+use VPlugins\BlogPostConnector\Endpoints\WebhookControl;
+use WP_Mock\Tools\TestCase;
+use WP_REST_Request;
+
+class WebhookControlTest extends TestCase {
+
+    /**
+     * @var WebhookControl
+     */
+    private $webhookControl;
+
+    /**
+     * Set up the test environment.
+     */
+    public function setUp(): void {
+        \WP_Mock::setUp();
+        $this->webhookControl = new WebhookControl();
+    }
+
+    /**
+     * Tear down the test environment.
+     */
+    public function tearDown(): void {
+        \WP_Mock::tearDown();
+        parent::tearDown();
+    }
+
+    /**
+     * Test that both the enable and disable routes are registered.
+     */
+    public function test_register_routes() {
+        \WP_Mock::userFunction('register_rest_route', [
+            'times' => 1,
+            'args' => [
+                'sm-connect/v1',
+                '/webhook/enable',
+                [
+                    'methods' => 'POST',
+                    'callback' => [$this->webhookControl, 'enable_webhook'],
+                    'permission_callback' => [true, 'permissions_check']
+                ]
+            ],
+        ]);
+
+        \WP_Mock::userFunction('register_rest_route', [
+            'times' => 1,
+            'args' => [
+                'sm-connect/v1',
+                '/webhook/disable',
+                [
+                    'methods' => 'POST',
+                    'callback' => [$this->webhookControl, 'disable_webhook'],
+                    'permission_callback' => [true, 'permissions_check']
+                ]
+            ],
+        ]);
+
+        $this->webhookControl->register_routes();
+
+        \WP_Mock::assertHooksAdded();
+    }
+
+    /**
+     * Test that enabling the webhook persists the enabled state and reports it back.
+     */
+    public function test_enable_webhook_sets_option_and_returns_enabled_status() {
+        \WP_Mock::userFunction('update_option', [
+            'times' => 1,
+            'args' => [WebhookControl::OPTION_NAME, '1'],
+            'return' => true,
+        ]);
+        \WP_Mock::userFunction('get_option', [
+            'args' => ['sm_post_connector_enable_logs'],
+            'return' => false,
+        ]);
+        \WP_Mock::userFunction('__', [
+            'return' => function ($text) {
+                return $text;
+            },
+        ]);
+
+        $request = \Mockery::mock(WP_REST_Request::class);
+
+        $response = $this->webhookControl->enable_webhook($request);
+
+        $this->assertEquals(200, $response->get_status());
+        $this->assertEquals('enabled', $response->get_data()['data']['webhook_status']);
+    }
+
+    /**
+     * Test that disabling the webhook persists the disabled state and reports it back.
+     */
+    public function test_disable_webhook_sets_option_and_returns_disabled_status() {
+        \WP_Mock::userFunction('update_option', [
+            'times' => 1,
+            'args' => [WebhookControl::OPTION_NAME, '0'],
+            'return' => true,
+        ]);
+        \WP_Mock::userFunction('get_option', [
+            'args' => ['sm_post_connector_enable_logs'],
+            'return' => false,
+        ]);
+        \WP_Mock::userFunction('__', [
+            'return' => function ($text) {
+                return $text;
+            },
+        ]);
+
+        $request = \Mockery::mock(WP_REST_Request::class);
+
+        $response = $this->webhookControl->disable_webhook($request);
+
+        $this->assertEquals(200, $response->get_status());
+        $this->assertEquals('disabled', $response->get_data()['data']['webhook_status']);
+    }
+
+    /**
+     * Test that repeated calls to disable an already-disabled webhook remain a success no-op.
+     */
+    public function test_disable_webhook_is_idempotent() {
+        \WP_Mock::userFunction('update_option', [
+            'times' => 2,
+            'args' => [WebhookControl::OPTION_NAME, '0'],
+            'return' => true,
+        ]);
+        \WP_Mock::userFunction('get_option', [
+            'args' => ['sm_post_connector_enable_logs'],
+            'return' => false,
+        ]);
+        \WP_Mock::userFunction('__', [
+            'return' => function ($text) {
+                return $text;
+            },
+        ]);
+
+        $request = \Mockery::mock(WP_REST_Request::class);
+
+        $first = $this->webhookControl->disable_webhook($request);
+        $second = $this->webhookControl->disable_webhook($request);
+
+        $this->assertEquals(200, $first->get_status());
+        $this->assertEquals(200, $second->get_status());
+        $this->assertEquals('disabled', $first->get_data()['data']['webhook_status']);
+        $this->assertEquals('disabled', $second->get_data()['data']['webhook_status']);
+    }
+
+    /**
+     * Test that is_enabled() defaults to true when the option has never been set.
+     */
+    public function test_is_enabled_defaults_to_true() {
+        \WP_Mock::userFunction('get_option', [
+            'args' => [WebhookControl::OPTION_NAME, '1'],
+            'return' => '1',
+        ]);
+
+        $this->assertTrue(WebhookControl::is_enabled());
+    }
+
+    /**
+     * Test that is_enabled() reflects a persisted disabled state.
+     */
+    public function test_is_enabled_reflects_disabled_option() {
+        \WP_Mock::userFunction('get_option', [
+            'args' => [WebhookControl::OPTION_NAME, '1'],
+            'return' => '0',
+        ]);
+
+        $this->assertFalse(WebhookControl::is_enabled());
+    }
+}

--- a/tests/includes/Webhook/WebhookTest.php
+++ b/tests/includes/Webhook/WebhookTest.php
@@ -2,7 +2,7 @@
 
 namespace VPlugins\BlogPostConnector\Tests\Webhook;
 
-use VPlugins\BlogPostConnector\Endpoints\WebhookControl;
+use VPlugins\BlogPostConnector\Helper\Globals;
 use VPlugins\BlogPostConnector\Webhook\Webhook;
 use WP_Mock\Tools\TestCase;
 
@@ -28,7 +28,7 @@ class WebhookTest extends TestCase {
      */
     public function test_trigger_webhook_is_skipped_when_disabled() {
         \WP_Mock::userFunction('get_option', [
-            'args' => [WebhookControl::OPTION_NAME, '1'],
+            'args' => [Globals::WEBHOOK_ENABLED_OPTION, '1'],
             'return' => '0',
         ]);
 
@@ -37,6 +37,8 @@ class WebhookTest extends TestCase {
         ]);
 
         Webhook::trigger_webhook(['action' => 'created']);
+
+        $this->assertConditionsMet();
     }
 
     /**
@@ -44,7 +46,7 @@ class WebhookTest extends TestCase {
      */
     public function test_trigger_webhook_sends_request_when_enabled() {
         \WP_Mock::userFunction('get_option', [
-            'args' => [WebhookControl::OPTION_NAME, '1'],
+            'args' => [Globals::WEBHOOK_ENABLED_OPTION, '1'],
             'return' => '1',
         ]);
 
@@ -58,5 +60,30 @@ class WebhookTest extends TestCase {
         ]);
 
         Webhook::trigger_webhook(['action' => 'created']);
+
+        $this->assertConditionsMet();
+    }
+
+    /**
+     * Test that forced payloads (plugin lifecycle events) are sent even while
+     * delivery is disabled, without consulting the flag at all.
+     */
+    public function test_trigger_webhook_sends_forced_request_while_disabled() {
+        \WP_Mock::userFunction('get_option', [
+            'times' => 0,
+        ]);
+
+        \WP_Mock::userFunction('wp_remote_post', [
+            'times' => 1,
+            'return' => ['response' => ['code' => 200]],
+        ]);
+
+        \WP_Mock::userFunction('is_wp_error', [
+            'return' => false,
+        ]);
+
+        Webhook::trigger_webhook(['action' => 'deactivated'], true);
+
+        $this->assertConditionsMet();
     }
 }

--- a/tests/includes/Webhook/WebhookTest.php
+++ b/tests/includes/Webhook/WebhookTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace VPlugins\BlogPostConnector\Tests\Webhook;
+
+use VPlugins\BlogPostConnector\Endpoints\WebhookControl;
+use VPlugins\BlogPostConnector\Webhook\Webhook;
+use WP_Mock\Tools\TestCase;
+
+class WebhookTest extends TestCase {
+
+    /**
+     * Set up the test environment.
+     */
+    public function setUp(): void {
+        \WP_Mock::setUp();
+    }
+
+    /**
+     * Tear down the test environment.
+     */
+    public function tearDown(): void {
+        \WP_Mock::tearDown();
+        parent::tearDown();
+    }
+
+    /**
+     * Test that no HTTP request is sent while webhook delivery is disabled.
+     */
+    public function test_trigger_webhook_is_skipped_when_disabled() {
+        \WP_Mock::userFunction('get_option', [
+            'args' => [WebhookControl::OPTION_NAME, '1'],
+            'return' => '0',
+        ]);
+
+        \WP_Mock::userFunction('wp_remote_post', [
+            'times' => 0,
+        ]);
+
+        Webhook::trigger_webhook(['action' => 'created']);
+    }
+
+    /**
+     * Test that the HTTP request is still sent while webhook delivery is enabled.
+     */
+    public function test_trigger_webhook_sends_request_when_enabled() {
+        \WP_Mock::userFunction('get_option', [
+            'args' => [WebhookControl::OPTION_NAME, '1'],
+            'return' => '1',
+        ]);
+
+        \WP_Mock::userFunction('wp_remote_post', [
+            'times' => 1,
+            'return' => ['response' => ['code' => 200]],
+        ]);
+
+        \WP_Mock::userFunction('is_wp_error', [
+            'return' => false,
+        ]);
+
+        Webhook::trigger_webhook(['action' => 'created']);
+    }
+}

--- a/tests/includes/Webhook/WebhookTest.php
+++ b/tests/includes/Webhook/WebhookTest.php
@@ -86,4 +86,39 @@ class WebhookTest extends TestCase {
 
         $this->assertConditionsMet();
     }
+
+    /**
+     * Test that the deactivation handler actually forces delivery.
+     *
+     * Covers the wiring rather than trigger_webhook() itself: dropping the
+     * force argument at the call site would silently re-mute lifecycle events.
+     */
+    public function test_plugin_deactivation_still_delivers_while_disabled() {
+        \WP_Mock::userFunction('get_option', [
+            'args' => [Globals::WEBHOOK_ENABLED_OPTION, '1'],
+            'return' => '0', // Delivery disabled.
+        ]);
+
+        \WP_Mock::userFunction('home_url', [
+            'return' => 'https://example.com',
+        ]);
+
+        \WP_Mock::userFunction('current_time', [
+            'return' => '2026-08-04 00:00:00',
+        ]);
+
+        \WP_Mock::userFunction('wp_remote_post', [
+            'times' => 1,
+            'return' => ['response' => ['code' => 200]],
+        ]);
+
+        \WP_Mock::userFunction('is_wp_error', [
+            'return' => false,
+        ]);
+
+        $webhook = new Webhook();
+        $webhook->trigger_webhook_on_plugin_deactivation('blog-post-connector/blog-post-connector.php');
+
+        $this->assertConditionsMet();
+    }
 }

--- a/uninstall.php
+++ b/uninstall.php
@@ -22,6 +22,7 @@ function sm_remove_options() {
         'sm_post_connector_default_category',
         'sm_post_connector_secret_key',
         'sm_post_connector_logo',
+        'sm_post_connector_webhook_enabled',
         '_transient_timeout_sm_post_connector_latest_release',
         '_site_transient_update_plugins',
     ];


### PR DESCRIPTION
## Summary
- Adds `POST /wp-json/sm-connect/v1/webhook/enable` and `/webhook/disable` so Social Marketing can stop/resume webhook delivery for a connection without deactivating the plugin (addresses webhooks firing against dead connections — SM-3919).
- Both endpoints use the existing Bearer-token auth (`AuthMiddleware`), are idempotent, and return the resulting state as `data.webhook_status` (`enabled`/`disabled`).
- State lives in `Helper\Globals` (`WEBHOOK_ENABLED_OPTION`, `is_webhook_enabled()`, `set_webhook_enabled()`), read by `Webhook::trigger_webhook()` before sending. Defaults to enabled, so existing installs are unaffected by the upgrade.
- `/status` also reports `webhook_status`, so SM can read the current state without toggling it.
- Bumps plugin version to 1.0.6, updates `CHANGELOG.md`, adds `docs/webhook-control.md` + `docs/index.md` entries.
- Pins `10up/phpcs-composer` to `^3.0` (was `dev-master`) — the old constraint pulled `wp-coding-standards/wpcs 2.3.0`, which Composer 2.9+ blocks as insecure, breaking `composer install`.

## One deliberate deviation, please confirm

Plugin **lifecycle** webhooks (`activated`, `deactivated`, `deleted`) intentionally **bypass** the disable flag; content/taxonomy/author webhooks are gated.

Gating everything meant that once SM disabled a connection, SM would never again receive an `activated` event — so a muted site had no signal that it was back, and the flag persists across deactivate/reactivate. Rather than clearing the option on activation (which would silently resume content sync to a still-dead connection — the exact SM-3919 failure), lifecycle events stay flowing: they're low-volume, they describe the connection rather than site content, and they give SM the trigger to call `/webhook/enable`. Re-enabling always remains an explicit SM call.

Happy to gate lifecycle events too if SM's reconnect path calls `/webhook/enable` unconditionally — it's a one-line change.

## Test plan
- [x] `composer install` succeeds cleanly.
- [x] PHPUnit suite green: **15 tests, 20 assertions** (PHP 8.3). Covers route registration, enable/disable state, idempotency (including `update_option()` returning `false` for an unchanged value), the failed-write→500 path, delivery skipped when disabled, delivery sent when enabled, and forced lifecycle delivery while disabled.
- [x] `phpcs --standard=PHPCompatibilityWP --runtime-set testVersion 7.4-8.4` clean on `includes/`.
- [ ] Manual: `POST /webhook/disable` → `200 {"webhook_status":"disabled"}`; publishing a post afterward sends no webhook. `POST /webhook/enable` → delivery resumes. Repeat calls stay `200`.

### Correction to my earlier note about the test suite

My original description blamed the suite failure on PHP 8.5 / Patchwork. That was wrong — thanks @MohanRaj168 for catching it. The actual cause was `tests/bootstrap.php` requiring the main plugin file, which calls `register_activation_hook()` at top level before WP_Mock defines any WP functions, aborting the run before any test executed. Since every plugin class is reachable through Composer's PSR-4 autoloader, that require was unnecessary; removing it plus stubbing `WP_REST_Response` (WP_Mock ships no WP classes) makes the suite run for the first time. That also surfaced a pre-existing `TokenTest` mock which no longer matched `validate_token()`'s `get_option($key, '')` call — fixed here.

Worth noting separately: no CI job runs phpunit (`release.yaml` is `workflow_dispatch`-only), which is why this went unnoticed. Out of scope here, but probably worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)